### PR TITLE
Shh docs

### DIFF
--- a/docs/shh.md
+++ b/docs/shh.md
@@ -8,9 +8,7 @@ Note that the configuration file is currently optimised for `nf-core/eager`. It
 will submit to the medium queue but with a walltime of 48 hours.
 
 ## Preparation
-
-Before running the pipeline you will need to create a the following folder in your `/projects1/users/` directory. This will be used to store the singularity software images, which
-will take up too much space for your home directory.
+Before running the pipeline you will need to create a the following folder in your `/projects1/users/` directory. This will be used to store the singularity software images, which will take up too much space for your home directory.
 
 This should be named as follows, replacing `<your_user>` with your username:
 

--- a/docs/uzh.md
+++ b/docs/uzh.md
@@ -1,6 +1,6 @@
 # nf-core/configs: UZH Configuration
 
-All nf-core pipelines have been successfully configured for use on the UZH cluster at the insert institution here.
+All nf-core pipelines have been successfully configured for use on the UZH cluster at the University of Zürich.
 
 To use, run the pipeline with `-profile uzh`. This will download and launch the [`uzh.config`](../conf/uzh.config) which has been pre-configured with a setup suitable for the UZH cluster. Using this profile, Nextflow will download a singularity image with all of the required software before execution of the pipeline.
 


### PR DESCRIPTION
Adds initial documentation for the MPI-SHH `shh.config` and fixes a typo for UZH.