### PR TITLE
Hotfix for breaking pipelines that don't already support params.custom_config_base

### DIFF
--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -8,24 +8,24 @@
  * name here.
  */
 
-default_uri = "https://raw.githubusercontent.com/nf-core/configs/master/conf"
-config_base = "${params.custom_config_base ?: default_uri}"
+params.custom_config_version = 'master'
+params.custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 
 profiles {
-  binac        { includeConfig "${config_base}/binac.config" }
-  ccga         { includeConfig "${config_base}/ccga.config" }
-  cfc          { includeConfig "${config_base}/cfc.config" }
-  crick        { includeConfig "${config_base}/crick.config" }
-  gis          { includeConfig "${config_base}/gis.config" }
-  hebbe        { includeConfig "${config_base}/hebbe.config" }
-  mendel       { includeConfig "${config_base}/mendel.config" }
-  munin        { includeConfig "${config_base}/munin.config" }
-  phoenix      { includeConfig "${config_base}/phoenix.config" }
-  shh          { includeConfig "${config_base}/shh.config" }
-  uct_hex      { includeConfig "${config_base}/uct_hex.config" }
-  uppmax_devel { includeConfig "${config_base}/uppmax.config"
-                 includeConfig "${config_base}/uppmax-devel.config"
+  binac        { includeConfig "${params.custom_config_base}/binac.config" }
+  ccga         { includeConfig "${params.custom_config_base}/ccga.config" }
+  cfc          { includeConfig "${params.custom_config_base}/cfc.config" }
+  crick        { includeConfig "${params.custom_config_base}/crick.config" }
+  gis          { includeConfig "${params.custom_config_base}/gis.config" }
+  hebbe        { includeConfig "${params.custom_config_base}/hebbe.config" }
+  mendel       { includeConfig "${params.custom_config_base}/mendel.config" }
+  munin        { includeConfig "${params.custom_config_base}/munin.config" }
+  phoenix      { includeConfig "${params.custom_config_base}/phoenix.config" }
+  shh          { includeConfig "${params.custom_config_base}/shh.config" }
+  uct_hex      { includeConfig "${params.custom_config_base}/uct_hex.config" }
+  uppmax_devel { includeConfig "${params.custom_config_base}/uppmax.config"
+                 includeConfig "${params.custom_config_base}/uppmax-devel.config"
   }
-  uppmax       { includeConfig "${config_base}/uppmax.config" }
-  uzh          { includeConfig "${config_base}/uzh.config" }
+  uppmax       { includeConfig "${params.custom_config_base}/uppmax.config" }
+  uzh          { includeConfig "${params.custom_config_base}/uzh.config" }
 }


### PR DESCRIPTION
Note that this fix means that we no longer need to include `params.custom_config_version` or `params.custom_config_base` in the main pipelines. But it doesn't seem to hurt if we do include them, they are just overwritten.

Phil