### PR TITLE
Removed params.config_profile_name, added params.hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ nextflow run /path/to/pipeline/ -c /path/to/my/configs/configs-master/conf/my_co
 
 If you decide to upload your custom config file to `nf-core/configs` then this will ensure that your custom config file will be automatically downloaded, and available at run-time to all nf-core pipelines, and to everyone within your organisation. You will simply have to specify `-profile <config_name>` in the command used to run the pipeline. See [`nf-core/configs`](https://github.com/nf-core/configs/tree/master/conf) for examples.
 
-Please also make sure to add an extra `params` section with `params.  config_profile_name`, `params.config_profile_description`, `params.config_profile_contact` and `params.config_profile_url` set to reasonable values. Users will get information on who wrote the configuration profile then when executing a nf-core pipeline and can report back if there are things missing for example.
+Please also make sure to add an extra `params` section with `params.config_profile_description`, `params.config_profile_contact` and `params.config_profile_url` set to reasonable values. Users will get information on who wrote the configuration profile then when executing a nf-core pipeline and can report back if there are things missing for example.
+
+## Checking user hostnames
+
+If your cluster has a set of consistent hostnames, nf-core pipelines can check that users are using your profile.
+Add one or more hostname substrings to `params.hostnames` under a key that matches the profile name.
+If the user's hostname contains this string at the start of a run or when a run fails and their profile
+does not contain the profile name, a warning message will be printed.
 
 ### Testing
 

--- a/conf/binac.config
+++ b/conf/binac.config
@@ -1,10 +1,10 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'BINAC'
   config_profile_description = 'BINAC cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Alexander Peltzer (@apeltzer)'
   config_profile_url = 'https://www.bwhpc-c5.de/wiki/index.php/Category:BwForCluster_BinAC'
 }
+
 singularity {
   enabled = true
 }

--- a/conf/ccga.config
+++ b/conf/ccga.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'CCGA'
   config_profile_description = 'CCGA cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Marc Hoeppner (@marchoeppner)'
   config_profile_url = 'https://www.ikmb.uni-kiel.de/'
@@ -25,7 +24,7 @@ process {
   clusterOptions = { "--qos=ikmb_a" }
 
 }
-  
+
 params {
   // illumina iGenomes reference file paths on RZCluster
   igenomes_base = '/ifs/data/nfs_share/ikmb_repository/references/iGenomes/references/'

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'CFC'
   config_profile_description = 'QBiC Core Facility cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Alexander Peltzer (@apeltzer)'
   config_profile_url = 'http://qbic.uni-tuebingen.de/'

--- a/conf/crick.config
+++ b/conf/crick.config
@@ -1,8 +1,7 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'CRICK'
   config_profile_description = 'The Francis Crick Institute CAMP HPC cluster profile provided by nf-core/configs.'
-  config_profile_contact = 'Harshil Patel (@drpatelh )'
+  config_profile_contact = 'Harshil Patel (@drpatelh)'
   config_profile_url = 'https://www.crick.ac.uk/research/platforms-and-facilities/scientific-computing/technologies'
 }
 

--- a/conf/gis.config
+++ b/conf/gis.config
@@ -1,11 +1,9 @@
-/*
- * -------------------------------------------------
- *  Nextflow config file for GIS (Aquila)
- * -------------------------------------------------
- * Defines reference genomes, using iGenome paths
- * Imported under the default 'standard' Nextflow
- * profile in nextflow.config
- */
+//Profile config names for nf-core/configs
+params {
+  config_profile_description = 'Genome Institute of Singapore (Aquila) cluster profile provided by nf-core/configs.'
+  config_profile_contact = 'Andreas Wilm (@andreas-wilm)'
+  config_profile_url = 'https://www.a-star.edu.sg/gis/'
+}
 
 process {
   executor = 'sge'
@@ -20,4 +18,3 @@ params {
   // illumina iGenomes reference file paths on GIS Aquila
   igenomes_base = '/mnt/projects/rpd/genomes.testing/S3_igenomes/'
 }
-

--- a/conf/hebbe.config
+++ b/conf/hebbe.config
@@ -1,8 +1,7 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'HEBBE'
   config_profile_description = 'Gothenburg Hebbe cluster profile provided by nf-core/configs.'
-  config_profile_contact = 'Phil Ewels (@ewels )'
+  config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'http://www.c3se.chalmers.se/index.php/Hebbe'
 }
 

--- a/conf/mendel.config
+++ b/conf/mendel.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'MENDEL'
   config_profile_description = 'GMI MENDEL cluster profile provided by nf-core/configs'
   config_profile_contact = 'Patrick Hüther (@phue)'
   config_profile_url = 'http://www.gmi.oeaw.ac.at/'

--- a/conf/munin.config
+++ b/conf/munin.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'MUNIN'
   config_profile_description = 'Big iron cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Szilveszter Juhos (@szilva)'
   config_profile_url = ''

--- a/conf/phoenix.config
+++ b/conf/phoenix.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'PHOENIX'
   config_profile_description = 'University of Adelaide Phoenix HPC cluster profile provided by nf-core/configs'
   config_profile_contact = 'Yassine Souilmi / Alexander Peltzer (@yassineS, @apeltzer)'
   config_profile_url = 'https://www.adelaide.edu.au/phoenix/'

--- a/conf/shh.config
+++ b/conf/shh.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'SHH'
   config_profile_description = 'MPI SHH cluster profile provided by nf-core/configs.'
   config_profile_contact = 'James Fellows Yates (@jfy133)'
   config_profile_url = 'https://shh.mpg.de'

--- a/conf/uct_hex.config
+++ b/conf/uct_hex.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'uct_hex'
   config_profile_description = 'University of Cape Town HEX cluster config file provided by nf-core/configs.'
   config_profile_contact = 'Katie Lennard (@kviljoen)'
   config_profile_url = 'http://hpc.uct.ac.za/index.php/hex-3/'
@@ -22,4 +21,3 @@ executor{
    executor = 'pbs'
    jobName = { "$task.tag" }
 }
-

--- a/conf/uppmax-devel.config
+++ b/conf/uppmax-devel.config
@@ -1,6 +1,5 @@
 // Profile config names for nf-core/configs
 params {
-  config_profile_name = 'UPPMAX-devel'
   config_profile_description = 'Testing & development profile for UPPMAX, provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_name = 'UPPMAX'
   config_profile_description = 'Swedish UPPMAX cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'

--- a/conf/uzh.config
+++ b/conf/uzh.config
@@ -1,6 +1,5 @@
 //Profile config names for nf-core/configs
 params{
-    config_profile_name = 'UZH'
     config_profile_description = 'UZH science cloud profile provided by nf-core/configs'
     config_profile_contact = 'Judith Neukamm/Alexander Peltzer (@JudithNeukamm, @apeltzer)'
     config_profile_url = 'https://www.id.uzh.ch/en/scienceit/infrastructure/sciencecloud.html'

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -23,7 +23,7 @@ profiles {
   phoenix      { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
   shh          { includeConfig "${params.custom_config_base}/conf/shh.config" }
   uct_hex      { includeConfig "${params.custom_config_base}/conf/uct_hex.config" }
-  uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config" includeConfig "${params.custom_config_base}/conf/uppmax-devel.config" }
+  uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-devel.config" }
   uppmax       { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
   uzh          { includeConfig "${params.custom_config_base}/conf/uzh.config" }
 }

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -23,9 +23,17 @@ profiles {
   phoenix      { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
   shh          { includeConfig "${params.custom_config_base}/conf/shh.config" }
   uct_hex      { includeConfig "${params.custom_config_base}/conf/uct_hex.config" }
-  uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config"
-                 includeConfig "${params.custom_config_base}/conf/uppmax-devel.config"
-  }
+  uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config" includeConfig "${params.custom_config_base}/conf/uppmax-devel.config" }
   uppmax       { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
   uzh          { includeConfig "${params.custom_config_base}/conf/uzh.config" }
+}
+
+// If user hostnames contain one of these substring and they are
+// not running the associated profile, it will trigger a warning message
+// Should be defined here for all profiles (not within profile config)
+params {
+  // This is a groovy map, not a nextflow parameter set
+  hostnames = [
+    uppmax: ['.uppmax.uu.se']
+  ]
 }


### PR DESCRIPTION
`params.config_profile_name` didn't seem to add anything beyond what we already had in the profile name, so I got rid of it.

I also added a new groovy map on the main config file called `params.hostnames`... Why? All will soon become clear...