### PR TITLE
add check_max function 

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,1 +1,34 @@
 includeConfig("nfcore_custom.config")
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+  if(type == 'memory'){
+    try {
+      if(obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'time'){
+    try {
+      if(obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if(type == 'cpus'){
+    try {
+      return Math.min( obj, params.max_cpus as int )
+    } catch (all) {
+      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+      return obj
+    }
+  }
+}


### PR DESCRIPTION
Add `check_max(obj,type)` function to [`nextflow.config`](https://github.com/nf-core/configs/blob/dev/nextflow.config) file

copied from [nf-core/rnaseq](https://github.com/nf-core/rnaseq/blob/dev/nextflow.config)

Is this the right place for that? Please feel free to edit this PR and leave a comment with your thoughts.