### PR TITLE
add queueSize limited to 5 for SHH short queue

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -13,6 +13,7 @@ singularity {
 process {
     executor = 'slurm'
     queue = 'short'
+    queueSize = 5
 }
 
 params {

--- a/conf/shh.config
+++ b/conf/shh.config
@@ -13,7 +13,7 @@ singularity {
 process {
     executor = 'slurm'
     queue = 'short'
-    queueSize = 5
+    queueSize = 16
 }
 
 params {


### PR DESCRIPTION
Limit queueSize to 5 simultaneous jobs.
Equivalent to a SLURM Job array of 5 simultaneous jobs.
@jfy133 