### PR TITLE
Add automounts for singularity

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -2,7 +2,7 @@
 params {
   config_profile_description = 'MPI SHH cluster profile provided by nf-core/configs.'
   config_profile_contact = 'James Fellows Yates (@jfy133)'
-  config_profile_url = 'https: //shh.mpg.de'
+  config_profile_url = 'https://shh.mpg.de'
 }
 
 singularity {

--- a/conf/shh.config
+++ b/conf/shh.config
@@ -2,11 +2,12 @@
 params {
   config_profile_description = 'MPI SHH cluster profile provided by nf-core/configs.'
   config_profile_contact = 'James Fellows Yates (@jfy133)'
-  config_profile_url = 'https://shh.mpg.de'
+  config_profile_url = 'https: //shh.mpg.de'
 }
 
 singularity {
     enabled = true
+    autoMounts = true
     cacheDir = "/projects1/singularity_scratch/cache/"
 }
 


### PR DESCRIPTION
Add automounts for singularity to fix the symlink handling.
>When a process input is a symbolic link file, make sure the linked file is stored in a host folder that is accessible from a bind path defined in your Singularity installation. Otherwise the process execution will fail because the launched container won’t be able to access the linked file.
https://www.nextflow.io/docs/latest/singularity.html

Solution described here: https://www.nextflow.io/docs/latest/config.html#config-singularity