### PR TITLE
updated singularity version in conf/prince.config to reflect version …

### DIFF
--- a/conf/prince.config
+++ b/conf/prince.config
@@ -1,4 +1,6 @@
 singularityDir = "$SCRATCH/singularity_images_nextflow"
+singularityModule = "singularity/3.2.1"
+squashfsModule = "squashfs/4.3"
 
 params {
     config_profile_description = """
@@ -17,8 +19,8 @@ singularity {
 
 process {
         beforeScript = """
-                          module load singularity/3.1.0
-                          module load squashfs/4.3
+                          module load $singularityModule 
+                          module load $squashfsModule 
                        """
                        .stripIndent()
         executor = 'slurm'


### PR DESCRIPTION
…installed on prince

The prince admins changed the singularity version to 3.2.1 from 3.1.0, making the old version unavailable. To keep this config functional, I updated the version number for singularity.