### PR TITLE
Multiple uppmax clusters

### DIFF
--- a/conf/uppmax-bianca.config
+++ b/conf/uppmax-bianca.config
@@ -1,0 +1,4 @@
+params {
+  max_memory = 125.GB
+  max_cpus = 16
+}

--- a/conf/uppmax-irma.config
+++ b/conf/uppmax-irma.config
@@ -1,0 +1,4 @@
+params {
+  max_memory = 250.GB
+  max_cpus = 16
+}

--- a/conf/uppmax-rackham.config
+++ b/conf/uppmax-rackham.config
@@ -1,0 +1,4 @@
+params {
+  max_memory = 125.GB
+  max_cpus = 20
+}

--- a/docs/uppmax.md
+++ b/docs/uppmax.md
@@ -3,13 +3,13 @@
 All nf-core pipelines have been successfully configured for use on the Swedish UPPMAX clusters.
 
 ## Using the UPPMAX config profile
-To use, run the pipeline with `-profile uppmax` (one hyphen). This will download and launch the [`uppmax.config`](../conf/uppmax.config) which has been pre-configured with a setup suitable for the UPPMAX servers. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
+To use, run the pipeline with `-profile uppmax-rackham`, `-profile uppmax-bianca` or `-profile uppmax-irma` (one hyphen). This will download and launch the general [`uppmax.config`](../conf/uppmax.config) together with the appropriate cluster specific config which has been pre-configured with a setup suitable for the UPPMAX servers. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
 
 In addition to this config profile, you will also need to specify an UPPMAX project id.
 You can do this with the `--project` flag (two hyphens) when launching nextflow. For example:
 
 ```bash
-nextflow run nf-core/PIPELINE -profile uppmax --project SNIC 2018/1-234 # ..rest of pipeline flags
+nextflow run nf-core/PIPELINE -profile uppmax-rackham --project SNIC 2018/1-234 # ..rest of pipeline flags
 ```
 
 Before running the pipeline you will need to either install Nextflow or load it using the environment module system.
@@ -21,8 +21,8 @@ Just run Nextflow on a login node and it will handle everything else.
 A local copy of the iGenomes resource has been made available on all UPPMAX clusters so you should be able to run the pipeline against any reference available in the `igenomes.config`.
 You can do this by simply using the `--genome <GENOME_ID>` parameter.
 
-## Running offline with Bianca
-If running on Bianca, you will have no internet connection and these configs will not be loaded.
+## Running offline with Bianca or Irma
+If running on Bianca or Irma, you will have no internet connection and these configs will not be loaded.
 Please use the nf-core helper tool on a different system to download the required pipeline files, and transfer them to bianca.
 This helper tool bundles the config files in this repo together with the pipeline files, so the profile will still be available.
 

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -28,6 +28,7 @@ profiles {
   uppmax_rackham  { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-rackham.config" }
   uppmax_irma     { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-irma.config" }
   uppmax_bianca   { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-bianca.config" }
+  uppmax          { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
   uzh             { includeConfig "${params.custom_config_base}/conf/uzh.config" }
   prince          { includeConfig "${params.custom_config_base}/conf/prince.config" }
   bigpurple       { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -12,23 +12,25 @@ params.custom_config_version = 'master'
 params.custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 
 profiles {
-  binac        { includeConfig "${params.custom_config_base}/conf/binac.config" }
-  ccga         { includeConfig "${params.custom_config_base}/conf/ccga.config" }
-  cfc          { includeConfig "${params.custom_config_base}/conf/cfc.config" }
-  crick        { includeConfig "${params.custom_config_base}/conf/crick.config" }
-  czbiohub_aws { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
-  gis          { includeConfig "${params.custom_config_base}/conf/gis.config" }
-  hebbe        { includeConfig "${params.custom_config_base}/conf/hebbe.config" }
-  mendel       { includeConfig "${params.custom_config_base}/conf/mendel.config" }
-  munin        { includeConfig "${params.custom_config_base}/conf/munin.config" }
-  phoenix      { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
-  shh          { includeConfig "${params.custom_config_base}/conf/shh.config" }
-  uct_hex      { includeConfig "${params.custom_config_base}/conf/uct_hex.config" }
-  uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-devel.config" }
-  uppmax       { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
-  uzh          { includeConfig "${params.custom_config_base}/conf/uzh.config" }
-  prince       { includeConfig "${params.custom_config_base}/conf/prince.config" }
-  bigpurple    { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }
+  binac           { includeConfig "${params.custom_config_base}/conf/binac.config" }
+  ccga            { includeConfig "${params.custom_config_base}/conf/ccga.config" }
+  cfc             { includeConfig "${params.custom_config_base}/conf/cfc.config" }
+  crick           { includeConfig "${params.custom_config_base}/conf/crick.config" }
+  czbiohub_aws    { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
+  gis             { includeConfig "${params.custom_config_base}/conf/gis.config" }
+  hebbe           { includeConfig "${params.custom_config_base}/conf/hebbe.config" }
+  mendel          { includeConfig "${params.custom_config_base}/conf/mendel.config" }
+  munin           { includeConfig "${params.custom_config_base}/conf/munin.config" }
+  phoenix         { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
+  shh             { includeConfig "${params.custom_config_base}/conf/shh.config" }
+  uct_hex         { includeConfig "${params.custom_config_base}/conf/uct_hex.config" }
+  uppmax_devel    { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-devel.config" }
+  uppmax_rackham  { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-rackham.config" }
+  uppmax_irma     { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-irma.config" }
+  uppmax_bianca   { includeConfig "${params.custom_config_base}/conf/uppmax.config"; includeConfig "${params.custom_config_base}/conf/uppmax-bianca.config" }
+  uzh             { includeConfig "${params.custom_config_base}/conf/uzh.config" }
+  prince          { includeConfig "${params.custom_config_base}/conf/prince.config" }
+  bigpurple       { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }
 }
 
 // If user hostnames contain one of these substring and they are


### PR DESCRIPTION
There are several clusters at [Uppmax](https://www.uppmax.uu.se/resources/systems/) with slightly different hardware. This PR adds these as separate profiles which all share a common `uppmax.conf` base config. The general uppmax profile is kept since a lot of documentation currently refers to this one. 

The memory parameter is transformed with the 1000/1024 factor to avoid requesting more MB memory than what is available.