### PR TITLE
added SCRATCH env var > fix travis of prince.config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 env:
   - NXF_VER='18.10.1' # Specify a minimum NF version that should be tested and work
   - NXF_VER='' # Plus: get the latest NF version and check, that it works
+  - SCRATCH='~'
 
 script:
   # Run the pipeline with the test profile and test remote config


### PR DESCRIPTION
The test-suite was failing for prince.config, because the singularity cachedir was defined dynamically by the environment variable $SCRATCH, which is set on the prince cluster but not on the travis server. This commit should fix that.