### PR TITLE
Missing Kraken in the config list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Currently documentation is available for the following clusters:
 * [CZBIOHUB_AWS_HIGHPRIORITY](docs/czbiohub.md)
 * [GIS](docs/gis.md)
 * [HEBBE](docs/hebbe.md)
+* [KRAKEN](docs/kraken.md)
 * [MENDEL](docs/mendel.md)
 * [MUNIN](docs/munin.md)
 * [PASTEUR](docs/pasteur.md)

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -22,6 +22,7 @@ profiles {
   czbiohub_aws_highpriority { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config"; includeConfig "${params.custom_config_base}/conf/czbiohub_aws_highpriority.config" }
   gis          { includeConfig "${params.custom_config_base}/conf/gis.config" }
   hebbe        { includeConfig "${params.custom_config_base}/conf/hebbe.config" }
+  kraken       { includeConfig "${params.custom_config_base}/conf/kraken.config" }
   mendel       { includeConfig "${params.custom_config_base}/conf/mendel.config" }
   munin        { includeConfig "${params.custom_config_base}/conf/munin.config" }
   pasteur      { includeConfig "${params.custom_config_base}/conf/pasteur.config" }


### PR DESCRIPTION
I've forgot to add `kraken` into `README` and `nfcore_custom.config`