### PR TITLE
Add profiles that should be shared with all pipelines to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ A repository for hosting nextflow config files containing custom parameters requ
 
 ## Using an existing config
 
-The Nextflow [`-c`](https://www.nextflow.io/docs/latest/config.html) parameter can be used with nf-core pipelines in order to load custom config files that you have available locally. However, if you or other people within your organisation are likely to be running nf-core pipelines regularly it may be a good idea to use/create a custom config file that defines some generic settings unique to the computing environment within your organisation.
+The Nextflow [`-c`](https://www.nextflow.io/docs/latest/config.html) parameter can be used with nf-core pipelines in order to load custom config files that you have available locally. However, if you or other people within your organization are likely to be running nf-core pipelines regularly it may be a good idea to use/create a custom config file that defines some generic settings unique to the computing environment within your organization.
 
 ### Configuration and parameters
 
 The config files hosted in this repository define a set of parameters which are specific to compute environments at different Institutions but generic enough to be used with all nf-core pipelines.
 
-All nf-core pipelines inherit the functionality provided by Nextflow, and as such custom config files can contain parameters/definitions that are available to both. For example, if you have the ability to use [Singularity](https://singularity.lbl.gov/) on your HPC you can add and customise the Nextflow [`singularity`](https://www.nextflow.io/docs/latest/config.html#scope-singularity) scope in your config file. Similarly, you can define a Nextflow [`executor`](https://www.nextflow.io/docs/latest/executor.html) depending on the job submission process available on your cluster. In contrast, the `params` section in your custom config file will typically define parameters that are specific to nf-core pipelines.
+All nf-core pipelines inherit the functionality provided by Nextflow, and as such custom config files can contain parameters/definitions that are available to both. For example, if you have the ability to use [Singularity](https://singularity.lbl.gov/) on your HPC you can add and customize the Nextflow [`singularity`](https://www.nextflow.io/docs/latest/config.html#scope-singularity) scope in your config file. Similarly, you can define a Nextflow [`executor`](https://www.nextflow.io/docs/latest/executor.html) depending on the job submission process available on your cluster. In contrast, the `params` section in your custom config file will typically define parameters that are specific to nf-core pipelines.
 
-You should be able to get a good idea as to how other people are customising the execution of their nf-core pipelines by looking at some of the config files in [`nf-core/configs`](https://github.com/nf-core/configs/tree/master/conf).
+You should be able to get a good idea as to how other people are customizing the execution of their nf-core pipelines by looking at some of the config files in [`nf-core/configs`](https://github.com/nf-core/configs/tree/master/conf).
 
 ### Offline usage
 
@@ -80,8 +80,9 @@ You will have to create a [Markdown document](https://www.markdownguide.org/gett
 
 See [`nf-core/configs/docs`](https://github.com/nf-core/configs/tree/master/docs) for examples.
 
-Currently documentation is available for the following clusters:
+Currently documentation is available for the following systems:
 
+* [AWSBATCH](docs/awsbatch.md)
 * [BIGPURPLE](docs/bigpurple.md)
 * [BINAC](docs/binac.md)
 * [CBE](docs/cbe.md)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A repository for hosting nextflow config files containing custom parameters requ
 
 ## Using an existing config
 
-The Nextflow [`-c`](https://www.nextflow.io/docs/latest/config.html) parameter can be used with nf-core pipelines in order to load custom config files that you have available locally. However, if you or other people within your organization are likely to be running nf-core pipelines regularly it may be a good idea to use/create a custom config file that defines some generic settings unique to the computing environment within your organization.
+The Nextflow [`-c`](https://www.nextflow.io/docs/latest/config.html) parameter can be used with nf-core pipelines in order to load custom config files that you have available locally. However, if you or other people within your organisation are likely to be running nf-core pipelines regularly it may be a good idea to use/create a custom config file that defines some generic settings unique to the computing environment within your organisation.
 
 ### Configuration and parameters
 
@@ -24,7 +24,7 @@ The config files hosted in this repository define a set of parameters which are 
 
 All nf-core pipelines inherit the functionality provided by Nextflow, and as such custom config files can contain parameters/definitions that are available to both. For example, if you have the ability to use [Singularity](https://singularity.lbl.gov/) on your HPC you can add and customize the Nextflow [`singularity`](https://www.nextflow.io/docs/latest/config.html#scope-singularity) scope in your config file. Similarly, you can define a Nextflow [`executor`](https://www.nextflow.io/docs/latest/executor.html) depending on the job submission process available on your cluster. In contrast, the `params` section in your custom config file will typically define parameters that are specific to nf-core pipelines.
 
-You should be able to get a good idea as to how other people are customizing the execution of their nf-core pipelines by looking at some of the config files in [`nf-core/configs`](https://github.com/nf-core/configs/tree/master/conf).
+You should be able to get a good idea as to how other people are customising the execution of their nf-core pipelines by looking at some of the config files in [`nf-core/configs`](https://github.com/nf-core/configs/tree/master/conf).
 
 ### Offline usage
 

--- a/conf/awsbatch.config
+++ b/conf/awsbatch.config
@@ -1,0 +1,14 @@
+//Nextflow config file for running on AWS batch
+
+params {
+  config_profile_name = 'AWSBATCH'
+  config_profile_description = 'AWSBATCH Cloud Profile'
+  config_profile_contact = 'Alexander Peltzer (@apeltzer)'
+  config_profile_url = 'https://aws.amazon.com/batch/'
+}
+
+aws.region = params.awsregion
+process.executor = 'awsbatch'
+process.queue = params.awsqueue
+executor.awscli = '/home/ec2-user/miniconda/bin/aws'
+params.tracedir = './'

--- a/docs/awsbatch.md
+++ b/docs/awsbatch.md
@@ -1,0 +1,4 @@
+# nf-core/configs: awsbatch Configuration
+
+To be used with `awsbatch`.
+Custom queue and region can be entered with `params.awsqueue` and `params.region` respectively.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -12,6 +12,7 @@ params.custom_config_version = 'master'
 params.custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 
 profiles {
+  awsbatch     { includeConfig "${params.custom_config_base}/conf/awsbatch.config" }
   bigpurple    { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }
   binac        { includeConfig "${params.custom_config_base}/conf/binac.config" }
   cbe          { includeConfig "${params.custom_config_base}/conf/cbe.config" }


### PR DESCRIPTION
I do think `test` and `debug` should be the only profiles to be specified at the pipeline level.

So I'd like to include the following profile here:
- awsbatch

I still think `conda`, `docker` and `singularity` should be included there, but I agree that we can do that one first, and then we'll see.