### PR TITLE
deprecate igenomesIgnore in favor of igenomes_ignore

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -18,5 +18,6 @@ params {
   params.max_time = 14.d
   params.max_cpus = 36
   params.max_memory = 4.TB
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
 }

--- a/conf/czbiohub_aws.config
+++ b/conf/czbiohub_aws.config
@@ -55,7 +55,8 @@ params {
   awsregion = "us-west-2"
   awsqueue = "nextflow"
 
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
 
   fc_extra_attributes = 'gene_name'
   fc_group_features = 'gene_id'

--- a/conf/genouest.config
+++ b/conf/genouest.config
@@ -16,7 +16,8 @@ process {
 }
 
 params {
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
   max_memory = 750.GB
   max_cpus = 80
   max_time = 336.h

--- a/conf/hebbe.config
+++ b/conf/hebbe.config
@@ -18,7 +18,8 @@ process {
 }
 
 params {
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
   saveReference = true
   max_memory = 64.GB
   max_cpus = 20

--- a/conf/mendel.config
+++ b/conf/mendel.config
@@ -19,5 +19,6 @@ params {
   max_cpus = 32
   max_memory = 128.GB
   max_time = 192.h
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
 }

--- a/conf/pasteur.config
+++ b/conf/pasteur.config
@@ -16,7 +16,8 @@ process {
 }
 
 params {
-  igenomesIgnore = true
+  igenomes_ignore = true
+  igenomesIgnore = true //deprecated
   max_memory = 256.GB
   max_cpus = 28
   max_time = 24.h


### PR DESCRIPTION
as discussed in https://github.com/nf-core/methylseq/pull/101

Let's keep both for now until all the pipelines have been synced.