### PR TITLE
Splitting SHH config to one per cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     needs: test_all_profiles
     strategy:
         matrix:
-            profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga', 'cfc', 'crick', 'denbi_qbic', 'genouest', 'gis', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh', 'uct_hex', 'uppmax_devel', 'uppmax', 'uzh']
+            profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga', 'cfc', 'crick', 'denbi_qbic', 'genouest', 'gis', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh_sdag', 'ssh_cdag', 'uct_hex', 'uppmax_devel', 'uppmax', 'uzh']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     needs: test_all_profiles
     strategy:
         matrix:
-            profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga', 'cfc', 'crick', 'denbi_qbic', 'genouest', 'gis', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh_sdag', 'ssh_cdag', 'uct_hex', 'uppmax_devel', 'uppmax', 'uzh']
+            profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga', 'cfc', 'crick', 'denbi_qbic', 'genouest', 'gis', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh_sdag', 'shh_cdag', 'uct_hex', 'uppmax_devel', 'uppmax', 'uzh']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/conf/shh_cdag.config
+++ b/conf/shh_cdag.config
@@ -1,0 +1,30 @@
+//Profile config names for nf-core/configs
+params {
+  config_profile_description = 'MPI-SHH CDAG cluster profile provided by nf-core/configs.'
+  config_profile_contact = 'James Fellows Yates (@jfy133), Maxime Borry (@Maxibor)'
+  config_profile_url = 'https://shh.mpg.de'
+}
+
+singularity {
+    enabled = true
+    autoMounts = true
+    runOptions = '-B /run/shm:/run/shm'
+    cacheDir = "/projects1/singularity_scratch/cache/"
+}
+
+process {
+    executor = 'slurm'
+    queue = { task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
+}
+
+executor {
+    queueSize = 16
+}
+
+params {
+  max_memory = 256.GB
+  max_cpus = 32
+  max_time = 720.h
+  //Illumina iGenomes reference file path
+  igenomes_base = "/projects1/public_data/igenomes/"
+}

--- a/conf/shh_sdag.config
+++ b/conf/shh_sdag.config
@@ -1,6 +1,6 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_description = 'MPI SHH cluster profile provided by nf-core/configs.'
+  config_profile_description = 'MPI-SHH SDAG cluster profile provided by nf-core/configs.'
   config_profile_contact = 'James Fellows Yates (@jfy133), Maxime Borry (@Maxibor)'
   config_profile_url = 'https://shh.mpg.de'
 }
@@ -14,7 +14,7 @@ singularity {
 
 process {
     executor = 'slurm'
-    queue = { task.memory > 756.GB ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
+    queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
 }
 
 executor {

--- a/docs/shh.md
+++ b/docs/shh.md
@@ -2,18 +2,15 @@
 
 All nf-core pipelines have been successfully configured for use on the Department of Archaeogenetic's SDAG/CDAG clusters at the [Max Planck Institute for the Science of Human History (MPI-SHH)](http://shh.mpg.de).
 
-To use, run the pipeline with `-profile shh`. This will download and launch the [`shh.config`](../conf/shh.config) which has been pre-configured with a setup suitable for the SDAG and CDAG clusters. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline. The image will currently be centrally stored here:
+To use, run the pipeline either with `-profile shh_sdag` or `-profile ssh_cdag`. This will download and launch the [`shh.config`](../conf/shh.config) which has been pre-configured with a setup suitable for the SDAG and CDAG clusters respectively. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline. The image will currently be centrally stored here:
 
 ```bash
 /projects1/singularity_scratch/cache/
 ```
 
-however this will likely change to a read-only directory in the future that will be managed by IT.
+however this will likely change to a read-only directory in the future that will be managed by the IT team.
 
-This configuration will automatically choose the correct SLURM queue (`short`,`medium`,`long`,`supercruncher`) depending on the time and memory required by each process.  
+This configuration will automatically choose the correct SLURM queue (`short`,`medium`,`long`) depending on the time and memory required by each process. `ssh_sdag` additionally allows for submission of jobs to the `supercruncher` when a job's requested memory exceeds 756GB.
 
-Please note that there is no `supercruncher` queue on CDAG.
-
->NB: You will need an account and VPN access to use the cluster at MPI-SHH in order to run the pipeline. If in doubt contact IT.
+>NB: You will need an account and VPN access to use the cluster at MPI-SHH in order to run the pipeline. If in doubt contact the IT team.
 >NB: Nextflow will need to submit the jobs via SLURM to the clusters and as such the commands above will have to be executed on one of the head nodes. If in doubt contact IT.
->NB: The maximum CPUs/Mem are currently adapted for SDAG resource maximums - i.e. will exceed CDAG. Be careful when running larges jobs that error-retries may exceed limits and get 'stuck' in SLURM.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -33,7 +33,8 @@ profiles {
   pasteur      { includeConfig "${params.custom_config_base}/conf/pasteur.config" }
   phoenix      { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
   prince       { includeConfig "${params.custom_config_base}/conf/prince.config" }
-  shh          { includeConfig "${params.custom_config_base}/conf/shh.config" }
+  shh_sdag     { includeConfig "${params.custom_config_base}/conf/shh_sdag.config" }
+  shh_cdag     { includeConfig "${params.custom_config_base}/conf/shh_cdag.config" }
   uct_hex      { includeConfig "${params.custom_config_base}/conf/uct_hex.config" }
   uppmax       { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
   uppmax_devel { includeConfig "${params.custom_config_base}/conf/uppmax.config"; 


### PR DESCRIPTION
Now have one config for SDAG and one for CDAG, as SDAG has an extra partition. Docs for each are both under docs/SHH.md.