### PR TITLE
Mini adjustment for `highmem` queue on denbi

### DIFF
--- a/conf/denbi_qbic.config
+++ b/conf/denbi_qbic.config
@@ -11,7 +11,7 @@ singularity {
 
 process {
   executor = 'pbs'
-  queue = 'batch'
+  queue = { task.memory > 64.GB ? 'highmem': 'batch'}
 }
 
 params {


### PR DESCRIPTION
Since we have two queues now on de.NBI (512GB nodes on highmem, 64GB ones on batch), we need to make this change to get the big nodes used :-) 
