### PR TITLE
Attempt to fix process specific configs with pipeline specific configs

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -9,8 +9,8 @@ params {
 // Specific nf-core/eager process configuration
 process {
   withName:malt {
-    memory = { check_max( 756.GB * task.attempt, 'memory' ) }
-    cpus = { check_max(64 * task.attempt, 'cpus') }
+    memory = {  756.GB * task.attempt ]
+    cpus = { 64 * task.attempt }
     time = 1440.h
     queue = { task.memory > 756.GB ? 'supercruncher': 'long' }
   }

--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -8,7 +8,7 @@ params {
 
 // Specific nf-core/eager process configuration
 process {
-  withName: malt {
+  withName:malt {
     memory = { check_max( 756.GB * task.attempt, 'memory' ) }
     cpus = { check_max(64 * task.attempt, 'cpus') }
     time = 1440.h

--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -12,6 +12,6 @@ process {
     memory = {  756.GB * task.attempt ]
     cpus = { 64 * task.attempt }
     time = 1440.h
-    queue = { task.memory > 756.GB ? 'supercruncher': 'long' }
+    queue = { task.memory > 756.GB ? 'supercruncher' : 'long' }
   }
 }

--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -4,6 +4,7 @@ params {
   // Specific nf-core/configs params
   config_profile_contact = 'James Fellows Yates (@jfy133)'
   config_profile_description = 'nf-core/eager SHH profile provided by nf-core/configs'
+  igenomes_base = "/projects1/public_data/igenomes/"
 }
 
 // Specific nf-core/eager process configuration

--- a/conf/shh.config
+++ b/conf/shh.config
@@ -29,7 +29,6 @@ params {
   igenomes_base = "/projects1/public_data/igenomes/"
 }
 
-
 profiles {
   cdag {
       config_profile_description = 'MPI-SHH CDAG profile, provided by nf-core/configs.'


### PR DESCRIPTION
SHH specific EAGER config is inherited (as seen by description), but increased resources not inherited. Removal of check_max will fix this, however can't test without merging because igenomes error when using `--custom_config_base` from https://github.com/jfy133/configs getting an `igenomes error`