### PR TITLE
Updates SHH specific nf-core/eager pipeline

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -10,8 +10,9 @@ params {
 // Specific nf-core/eager process configuration
 process {
   withName: malt {
-    memory = {  725.GB * task.attempt }
-    cpus = { 64 * task.attempt }
+    maxRetries = 1
+    memory = {  task.attempt > 1 ? 1900.GB : 725.GB }
+    cpus = { task.attempt > 1 ? 112 : 64 }
     time = 1440.h
     queue = { task.memory > 756.GB ? 'supercruncher' : 'long' }
   }

--- a/docs/pipeline/eager/shh.md
+++ b/docs/pipeline/eager/shh.md
@@ -14,4 +14,4 @@ Example: `nextflow run nf-core/eager -profile shh`
 
 Specific configurations for shh has been made for eager.
 
-* If running with the MALT module turned on, the MALT process by default will be sent either to the long queues with a resource requirement minimum of 725GB and 64 cores. If this fails, the process will be tried once more only and sent to the supercruncher queue. The module will not retry after this, and pipeline will fail.
+* If running with the MALT module turned on, the MALT process by default will be sent  to the long queue with a resource requirement minimum of 725GB and 64 cores. If this fails, the process will be tried once more only and sent to the supercruncher queue. The module will not retry after this, and pipeline will fail.

--- a/docs/pipeline/eager/shh.md
+++ b/docs/pipeline/eager/shh.md
@@ -14,4 +14,4 @@ Example: `nextflow run nf-core/eager -profile shh`
 
 Specific configurations for shh has been made for eager.
 
-* Running with the MALT module turned on, will by default be sent either to long or supercruncher queues with a minimum of 756GB and 64 cores.
+* If running with the MALT module turned on, the MALT process by default will be sent either to the long queues with a resource requirement minimum of 725GB and 64 cores. If this fails, the process will be tried once more only and sent to the supercruncher queue. The module will not retry after this, and pipeline will fail.


### PR DESCRIPTION
A out of balance default resource setup lead to instant successive retries of MALT until resource requirements of queue were exceeded. Simplified to just two options avaliable.