### PR TITLE
Update binac.config

### DIFF
--- a/conf/binac.config
+++ b/conf/binac.config
@@ -14,7 +14,7 @@ process {
   beforeScript = 'module load devel/singularity/3.4.2'
   executor = 'pbs'
   queue = 'short'
-  process.queue = { task.memory > 128.GB ? 'smp': task.time <= 20.m ? 'tiny' : task.time <= 48.h ? 'short' : task.time <= 168.h ? 'short' : 'long'}
+  process.queue = { task.memory >= 128.GB ? 'smp': task.time <= 20.m ? 'tiny' : task.time <= 48.h ? 'short' : task.time <= 168.h ? 'short' : 'long'}
 }
 
 params {


### PR DESCRIPTION
Processes that ask for 128 Gb are queuing forever when on short queue, but executed when send to smp queue.