### PR TITLE
Remove params.custom_config_base from nf-core/configs

### DIFF
--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -8,9 +8,6 @@
  * name here.
  */
 
-params.custom_config_version = 'master'
-params.custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
-
 //Please use a new line per include Config section to allow easier linting/parsing. Thank you.
 profiles {
   awsbatch     { includeConfig "${params.custom_config_base}/conf/awsbatch.config" }
@@ -23,8 +20,8 @@ profiles {
   cfc          { includeConfig "${params.custom_config_base}/conf/cfc.config" }
   crick        { includeConfig "${params.custom_config_base}/conf/crick.config" }
   czbiohub_aws { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
-  czbiohub_aws_highpriority { 
-                 includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config"; 
+  czbiohub_aws_highpriority {
+                 includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config";
                  includeConfig "${params.custom_config_base}/conf/czbiohub_aws_highpriority.config"}
   genotoul     { includeConfig "${params.custom_config_base}/conf/genotoul.config" }
   denbi_qbic   { includeConfig "${params.custom_config_base}/conf/denbi_qbic.config" }


### PR DESCRIPTION
We just came across a nasty problem with this setup on our new deployments:

1. `nf-core download` pulls pipelines, and changes `params.custom_config_base` in the pipeline `nextflow.config` file so that it points to the correct directory where the configs have been downloaded
2. The configs `nfcore_custom.config` is correctly loaded, but then `params.custom_config_base` is set again which overwrites the pipeline definition.
3. Because we're offline, we cannot load the profile config files

This is particularly tricky because of how different config parameters are dealt with: if you specify `--custom_config_base` on the command line, it works, because that takes priority and isn't overwritten.

Simple fix is, I think, to just delete these lines from nf-core/configs. They should always be defined in the pipelines that import these files, so I think that they are redundant. We tested locally and it does indeed seem to solve our problem.

Phil