### PR TITLE
cbe: move container cache to different filesystem

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -14,7 +14,7 @@ process {
 
 singularity {
   enabled = true
-  cacheDir = '/scratch-cbe/shared/containers'
+  cacheDir = '/resources/containers'
 }
 
 params {


### PR DESCRIPTION
this is a workaround for squashfs errors that occur when containers are run from beeGFS