### PR TITLE
Update cfc.config

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -13,6 +13,7 @@ singularity {
 process {
   beforeScript = 'module load devel/singularity/3.4.2'
   executor = 'slurm'
+  queue = { task.memory > 60.GB || task.cpus > 20 ? 'qbic' }
 }
 
 weblog{
@@ -22,7 +23,7 @@ weblog{
 
 params {
   igenomes_base = '/nfsmounts/igenomes'
-  max_memory = 498.GB
-  max_cpus = 20
+  max_memory = 1999.GB
+  max_cpus = 128
   max_time = 140.h
 }

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -13,7 +13,7 @@ singularity {
 process {
   beforeScript = 'module load devel/singularity/3.4.2'
   executor = 'slurm'
-  queue = { task.memory > 60.GB || task.cpus > 20 ? 'qbic' }
+  queue = { task.memory > 60.GB || task.cpus > 20 ? 'qbic' : 'compute' }
 }
 
 weblog{


### PR DESCRIPTION
We just added some new HighMem nodes to the cfc, Partition/queue name is qbic, each node has 128Cores and 2TB of RAM.
The old queue (Name compute) is set to default by slurm.
Each process over 60GB of RAM or over 20cpus should run on those new nodes.
So added the queue State and adjusted the max_memory and max_cpu setting.