### PR TITLE
add cfc_dev profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     needs: test_all_profiles
     strategy:
         matrix:
-          profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga_med', 'cfc', 'crick', 'denbi_qbic', 'ebc', 'genotoul', 'genouest', 'gis', 'google', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh', 'uct_hex', 'uppmax', 'utd_ganymede', 'uzh']
+          profile: ['awsbatch', 'bigpurple', 'binac', 'cbe', 'ccga_dx', 'ccga_med', 'cfc', 'cfc_dev', 'crick', 'denbi_qbic', 'ebc', 'genotoul', 'genouest', 'gis', 'google', 'hebbe', 'kraken', 'munin', 'pasteur', 'phoenix', 'prince', 'shh', 'uct_hex', 'uppmax', 'utd_ganymede', 'uzh']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -1,13 +1,12 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_description = 'QBiC Core Facility cluster profile provided by nf-core/configs.'
+  config_profile_description = 'QBiC Core Facility cluster dev profile without container cache provided by nf-core/configs.'
   config_profile_contact = 'Gisela Gabernet (@ggabernet)'
   config_profile_url = 'http://qbic.uni-tuebingen.de/'
 }
 
 singularity {
   enabled = true
-  cacheDir = '/nfsmounts/container'
 }
 
 process {

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -17,6 +17,7 @@ profiles {
   ccga_dx      { includeConfig "${params.custom_config_base}/conf/ccga_dx.config" }
   ccga_med     { includeConfig "${params.custom_config_base}/conf/ccga_med.config" }
   cfc          { includeConfig "${params.custom_config_base}/conf/cfc.config" }
+  cfc_dev      { includeConfig "${params.custom_config_base}/conf/cfc_dev.config" }
   crick        { includeConfig "${params.custom_config_base}/conf/crick.config" }
   czbiohub_aws { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
   czbiohub_aws_highpriority {
@@ -47,7 +48,9 @@ profiles {
 params {
   // This is a groovy map, not a nextflow parameter set
   hostnames = [
+    binac: ['.binac.uni-tuebingen.de'],
     cbe: ['.cbe.vbc.ac.at'],
+    cfc: ['.hpc.uni-tuebingen.de'],
     crick: ['.thecrick.org'],
     genotoul: ['.genologin1.toulouse.inra.fr', '.genologin2.toulouse.inra.fr'],
     genouest: ['.genouest.org'],


### PR DESCRIPTION
- Adding cfc_dev profile to be able to run pipelines with -r dev without caching containers
- Adding warnings when people are running pipelines in binac or cfc without the corresponding profiles