### PR TITLE
[UPPMAX] add s.* pattern for bianca cluster

### DIFF
--- a/conf/pipeline/sarek/uppmax.config
+++ b/conf/pipeline/sarek/uppmax.config
@@ -9,7 +9,7 @@ params {
   igenomeIgnore = true
   genomes_base = params.genome == 'GRCh37' ? '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37' : '/sw/data/uppnex/ToolBox/hg38bundle'
 }
- if (hostname ==~ "r.*") {
+if (hostname ==~ "r.*") {
   params.singleCPUmem = 6400.MB
 }
 if (hostname ==~ "i.*") {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -26,7 +26,7 @@ params {
 
 def hostname = "hostname".execute().text.trim()
 
-if (hostname ==~ "b.*") {
+if (hostname ==~ "b.*" || hostname ==~ "s.*") {
   params.max_memory = 109.GB
 }
 


### PR DESCRIPTION
I'm adding this s.* pattern for bianca cluster, since the hostnames get a name like `senseproject...`