### PR TITLE
CBE: don't load singularity module

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -7,7 +7,6 @@ params {
 
 process {
   executor = 'slurm'
-  module = 'singularity/3.4.1'
   queue = { task.memory <= 170.GB ? 'c' : 'm' }
   clusterOptions = { task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
 }

--- a/docs/cbe.md
+++ b/docs/cbe.md
@@ -4,13 +4,12 @@ All nf-core pipelines have been successfully configured for use on the CLIP BATC
 
 To use, run the pipeline with `-profile cbe`. This will download and launch the [`cbe.config`](../conf/cbe.config) which has been pre-configured with a setup suitable for the CBE cluster. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
 
-Before running the pipeline you will need to load Nextflow and Singularity using the environment module system on CBE. You can do this by issuing the commands below:
+Before running the pipeline you will need to load Nextflow using the environment module system on CBE. You can do this by issuing the commands below:
 
 ```bash
-## Load Nextflow and Singularity environment modules
+## Load Nextflow environment module
 module purge
 module load nextflow/19.04.0
-module load singularity/3.2.1
 ```
 
 A local copy of the [AWS-iGenomes](https://registry.opendata.aws/aws-igenomes/) resource has been made available on CBE so you should be able to run the pipeline against any reference available in the `igenomes.config` specific to the nf-core pipeline. You can do this by simply using the `--genome <GENOME_ID>` parameter.


### PR DESCRIPTION
Singularity is now installed from CentOS repos, the environment module will be removed in the near future.