### PR TITLE
Set params.custom_config_base in nextflow.config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Check whether profiles are all tested
-        run: |
-          python ${GITHUB_WORKSPACE}/bin/cchecker.py ${GITHUB_WORKSPACE}/nfcore_custom.config ${GITHUB_WORKSPACE}/.github/workflows/main.yml
+        run: python ${GITHUB_WORKSPACE}/bin/cchecker.py ${GITHUB_WORKSPACE}/nfcore_custom.config ${GITHUB_WORKSPACE}/.github/workflows/main.yml
+      - run: nextflow config -show-profiles .
   profile_test:
     runs-on: ubuntu-latest
     name: Run ${{ matrix.profile }} profile
@@ -24,7 +24,4 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
       - name: Check ${{ matrix.profile }} profile
-        env:
-          SCRATCH: '~'
-          NXF_GLOBAL_CONFIG: awsbatch.config
         run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf -profile ${{ matrix.profile }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: Configs tests
 
 on: [pull_request, push]
+
 jobs:
+
   test_all_profiles:
     runs-on: ubuntu-latest
     name: Check if all profiles are tested
@@ -9,7 +11,18 @@ jobs:
       - uses: actions/checkout@v1
       - name: Check whether profiles are all tested
         run: python ${GITHUB_WORKSPACE}/bin/cchecker.py ${GITHUB_WORKSPACE}/nfcore_custom.config ${GITHUB_WORKSPACE}/.github/workflows/main.yml
-      - run: nextflow config -show-profiles .
+
+  check_nextflow_config:
+    runs-on: ubuntu-latest
+    name: Check if nextflow config runs in repository root
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - run: nextflow config -show-profiles ${GITHUB_WORKSPACE}
+
   profile_test:
     runs-on: ubuntu-latest
     name: Run ${{ matrix.profile }} profile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,4 @@ jobs:
         env:
           SCRATCH: '~'
           NXF_GLOBAL_CONFIG: awsbatch.config
-        run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf --custom_config_base=${GITHUB_WORKSPACE} -profile ${{ matrix.profile }}
+        run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf -profile ${{ matrix.profile }}

--- a/conf/prince.config
+++ b/conf/prince.config
@@ -1,6 +1,6 @@
-singularityDir = "$SCRATCH/singularity_images_nextflow"
-singularityModule = "singularity/3.2.1"
-squashfsModule = "squashfs/4.3"
+def singularityDir = set_singularity_path()
+def singularityModule = "singularity/3.2.1"
+def squashfsModule = "squashfs/4.3"
 
 params {
     config_profile_description = """
@@ -13,11 +13,21 @@ params {
 }
 
 singularity {
-      enabled = true
-      cacheDir = singularityDir
+    enabled = true
+    cacheDir = singularityDir
 }
 
 process {
         beforeScript = "module load $singularityModule $squashfsModule"
         executor = 'slurm'
+}
+
+def set_singularity_path() {
+    def scratch = System.getenv('SCRATCH')
+    if(scratch == null){
+        System.err.println("WARNING: prince.config requires the SCRATCH env var to be set.")
+        return null
+    } else {
+        return "$SCRATCH/singularity_images_nextflow"
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,1 +1,2 @@
+params.custom_config_base = "."
 includeConfig("nfcore_custom.config")


### PR DESCRIPTION
Fixes error reported in #162:

```console
$ nextflow config -show-profiles .
No such file: Config file does not exist: /Users/philewels/GitHub/nf-core/configs/[:]/conf/awsbatch.config
```

Basically nothing uses this main `nextflow.config` file, so I think that this change will make very little difference. Pipelines import the `nf_custom.config` file directly and the CI tests set `--custom_config_base` on the command line.