### PR TITLE
Fixing an autoMounts bug for icr_davros

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Currently documentation is available for the following systems:
 * [GIS](docs/gis.md)
 * [GOOGLE](docs/google.md)
 * [HEBBE](docs/hebbe.md)
+* [ICR_DAVROS](docs/icr_davros.md)
 * [KRAKEN](docs/kraken.md)
 * [MUNIN](docs/munin.md)
 * [PASTEUR](docs/pasteur.md)

--- a/conf/icr_davros.config
+++ b/conf/icr_davros.config
@@ -13,8 +13,8 @@ params {
 
 singularity {
   enabled = true
-  // runOptions = "--bind /mnt:/mnt --bind /data:/data"
-  autoMounts = true
+  runOptions = "--bind /mnt:/mnt --bind /data:/data"
+  // autoMounts = true // autoMounts sometimes causes a rare bug with the installed version of singularity
 }
 
 executor {


### PR DESCRIPTION
Have found a bug with our version of Singularity and autoMounts which manifests in only some processes. Not sure why but we cannot change the version of Singularity so going back to explicitly defining the mount points. 

Also added icr_davros to the list in README.md that Id missed before. 