### PR TITLE
Bump number of eager @shh retries to account for deep sequencing data

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -13,6 +13,9 @@ params {
 
 // Specific nf-core/eager process configuration
 process {
+
+  maxRetries = 5
+
   withName: malt {
     maxRetries = 1
     memory = {  task.attempt > 1 ? 1900.GB : 725.GB }


### PR DESCRIPTION
We could also try bumping the number of CPUs to also speed things up, but I'm concerned we could spam the queues...