### PR TITLE
Remove default non-profile bwa parameters from eager profile

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -5,11 +5,7 @@ params {
   config_profile_contact = 'James Fellows Yates (@jfy133)'
   config_profile_description = 'nf-core/eager SHH profile provided by nf-core/configs'
   igenomes_base = "/projects1/public_data/igenomes/"
-  
-  // default BWA
-   bwaalnn = 0.04
-   bwaalnl = 32
-}
+ }
 
 // Specific nf-core/eager process configuration
 process {


### PR DESCRIPTION
I realised today this is dangerous as these would not necessarily be reported if a user doesn't understand the profiles. Therefore removing these two parameters, so that nf-core/eager defaults are always used unless a specific profile (which would be described in the command itself reported in a publication) is explicitly named.