### PR TITLE
Remove now deprecated EAGER flag for HOPS profile

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -76,7 +76,6 @@ profiles {
       bwaalnn = 0.01
       bwaalnl = 16
       run_bam_filtering = true
-      bam_discard_unmapped = true
       bam_unmapped_type = 'fastq'
       run_metagenomic_screening = true
       metagenomic_tool = 'malt'


### PR DESCRIPTION
I simplified the parameters to specify BAM filtering for nf-core/eager. This removes the now deprecated parameters from profiles.