### PR TITLE
Add temporary CDAG setting for SHH config

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -33,6 +33,10 @@ profiles {
     params {
       config_profile_description = 'CDAG MPI-SHH profile, provided by nf-core/configs.'
     }
+    // delete when CDAG will be fixed
+    process {
+      queue = 'long'
+    }
   }
   sdag {
     params {


### PR DESCRIPTION
Until CDAG is fixed, there is only one queue (`long`)