### PR TITLE
Add new group profile for eager@SHH

### DIFF
--- a/conf/pipeline/eager/shh.config
+++ b/conf/pipeline/eager/shh.config
@@ -65,6 +65,18 @@ process {
 }
 
 profiles {
+  microbiome_screening {
+    process {
+      // Assuming NCBI NT-sized DB
+      withName: malt {
+        maxRetries = 1
+        memory = 1900.GB
+        cpus = 112
+        time = 1440.h
+        queue = 'supercruncher'
+      }
+    }
+  }
   // IMPORTANT this profile is not reproducible due to hardcoded paths. For initial/automated screening ONLY.
   hops {
     params {

--- a/docs/pipeline/eager/shh.md
+++ b/docs/pipeline/eager/shh.md
@@ -20,6 +20,10 @@ Specific configurations for shh has been made for eager.
 
 ### Contextual profiles
 
+#### Microbiome Sciences
+
+* `microbiome_screening` runs MALT straight to supercruncher (with no retries!) and full resources requested due to microbiome screening databases often easily reach this size
+
 #### Human Pop-Gen
 
 * `human`: optimised for mapping of human aDNA reads (i.e. bwa aln defaults as `-l 16500, -n 0.01`)


### PR DESCRIPTION
Adds microbiome_screening profile to send eager MALT runs straight to supercruncher with full resources as our databases normally need that.