### PR TITLE
Remove custom singularity runOptions from SHH config

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -15,7 +15,6 @@ cleanup = true
 singularity {
     enabled = true
     autoMounts = true
-    runOptions = '-B /run/shm:/run/shm'
     cacheDir = "/projects1/singularity_scratch/cache/"
 }
 


### PR DESCRIPTION
As per discussion on mattermost

(and apparently identified by @drpatelh with nanoseq?)