### PR TITLE
Move sdag queue specification block in sdag profile

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -20,7 +20,6 @@ singularity {
 
 process {
     executor = 'slurm'
-    queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
 }
 
 executor {
@@ -42,6 +41,7 @@ profiles {
       config_profile_description = 'SDAG MPI-SHH profile, provided by nf-core/configs.'
       max_memory = 2.TB
       max_cpus = 128
+      queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
      }
   }
 }

--- a/conf/shh.config
+++ b/conf/shh.config
@@ -38,10 +38,12 @@ profiles {
   }
   sdag {
     params {
-      config_profile_description = 'SDAG MPI-SHH profile, provided by nf-core/configs.'
-      max_memory = 2.TB
-      max_cpus = 128
-      queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
+          config_profile_description = 'SDAG MPI-SHH profile, provided by nf-core/configs.'
+          max_memory = 2.TB
+          max_cpus = 128
+      }
+      process {
+          queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
      }
   }
 }


### PR DESCRIPTION
Minor changes.

I moved the queue specification block from within `params` to the `sdag` profile. 
The moved queue specification block should be specific to sdag, and specified within that profile for consistency and ease of finding the specification block.