### PR TITLE
Add debug profile

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -10,6 +10,7 @@ params {
   igenomes_base = "/projects1/public_data/igenomes/"
 }
 
+// Preform work directory cleanup after a successful run
 cleanup = true
 
 singularity {
@@ -45,5 +46,9 @@ profiles {
       process {
           queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
      }
+  }
+  // Profile to deactivate automatic cleanup of work directory after a successful run. Overwrites cleanup option.
+  debug {
+    cleanup = false
   }
 }


### PR DESCRIPTION
which deactivates cleanup of workdir after successful run. Useful for debugging and testing of code changes, as it is possible to see exactly what the process did on successful runs.