### PR TITLE
Update shh config after CDAG departure

### DIFF
--- a/conf/shh.config
+++ b/conf/shh.config
@@ -1,10 +1,10 @@
 //Profile config names for nf-core/configs
 params {
-  config_profile_description = 'Generic MPI-SHH cluster(s) profile provided by nf-core/configs.'
+  config_profile_description = 'Generic MPI-SHH SDAG cluster profile provided by nf-core/configs.'
   config_profile_contact = 'James Fellows Yates (@jfy133), Maxime Borry (@Maxibor)'
   config_profile_url = 'https://shh.mpg.de'
-  max_memory = 256.GB
-  max_cpus = 32
+  max_memory = 2.TB
+  max_cpus = 128
   max_time = 720.h
   //Illumina iGenomes reference file path
   igenomes_base = "/projects1/public_data/igenomes/"
@@ -13,14 +13,9 @@ params {
 // Preform work directory cleanup after a successful run
 cleanup = true
 
-singularity {
-    enabled = true
-    autoMounts = true
-    cacheDir = "/projects1/singularity_scratch/cache/"
-}
-
 process {
     executor = 'slurm'
+    queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
 }
 
 executor {
@@ -28,24 +23,10 @@ executor {
 }
 
 profiles {
-  cdag {
-    params {
-      config_profile_description = 'CDAG MPI-SHH profile, provided by nf-core/configs.'
-    }
-    // delete when CDAG will be fixed
-    process {
-      queue = 'long'
-    }
-  }
-  sdag {
-    params {
-          config_profile_description = 'SDAG MPI-SHH profile, provided by nf-core/configs.'
-          max_memory = 2.TB
-          max_cpus = 128
-      }
-      process {
-          queue = { task.memory > 756.GB || task.cpus > 64 ? 'supercruncher': task.time <= 2.h ? 'short' : task.time <= 48.h ? 'medium': 'long' }
-     }
+  singularity {
+    singularity.enabled = true
+    singularity.autoMounts = true
+    singularity.cacheDir = "/projects1/singularity_scratch/cache/"
   }
   // Profile to deactivate automatic cleanup of work directory after a successful run. Overwrites cleanup option.
   debug {


### PR DESCRIPTION
- Removed CDAG profile (after its departure to MPI-EVA)
- Moved SDAG profile to SHH 
- Put Singularity in a dedicated profile, otherwise, we can't use the SHH profile with something else (like conda for example)