### PR TITLE
cbe: add rapid qos

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -2,13 +2,13 @@
 params {
   config_profile_description = 'CLIP BATCH ENVIRONMENT (CBE) cluster profile provided by nf-core/configs'
   config_profile_contact = 'Patrick Hüther (@phue)'
-  config_profile_url = 'http://www.gmi.oeaw.ac.at/'
+  config_profile_url = 'https://clip.science'
 }
 
 process {
   executor = 'slurm'
   queue = { task.memory <= 170.GB ? 'c' : 'm' }
-  clusterOptions = { task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
+  clusterOptions = { task.time <= 1.h ? '--qos rapid' : task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
   module = 'anaconda3/2019.10'
 }
 


### PR DESCRIPTION
Slurm config changed a bit, this accounts for it.
Also the config profile url now points to the dedicated cluster website