### PR TITLE
Remove "/rdsgpfs"

### DIFF
--- a/conf/imperial.config
+++ b/conf/imperial.config
@@ -27,7 +27,7 @@ executor {
 singularity {
   enabled = true
   autoMounts = true
-  runOptions = "-B /rds/,/rdsgpfs/,/rds/general/user/$USER/ephemeral/tmp/:/tmp,/rds/general/user/$USER/ephemeral/tmp/:/var/tmp"
+  runOptions = "-B /rds/,/rds/general/user/$USER/ephemeral/tmp/:/tmp,/rds/general/user/$USER/ephemeral/tmp/:/var/tmp"
 }
 
 process {


### PR DESCRIPTION
"/rdsgpfs" symlink will not be present on all nodes. Without that mount the container creation will fail.