### PR TITLE
UPPMAX: Avoid undefined parameter warnings

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -1,8 +1,10 @@
-//Profile config names for nf-core/configs
+// Profile config names for nf-core/configs
 params {
   config_profile_description = 'Swedish UPPMAX cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'
+  project = null
+  clusterOptions = null
 }
 
 singularity {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -5,6 +5,7 @@ params {
   config_profile_url = 'https://www.uppmax.uu.se/'
   project = null
   clusterOptions = null
+  schema_ignore_params = "genomes,input_paths,cluster-options,clusterOptions,project"
 }
 
 singularity {


### PR DESCRIPTION
Fixes error without needing the parameter to be added to the pipeline config:

```
WARN: Access to undefined parameter `project` -- Initialise it to a default value eg. `params.project = some_value
```

Adds param names to `schema_ignore_params` so that theoretically they do not trigger a linting warning:

```
WARN: Found unexpected parameters:
* --cluster-options: null
* --clusterOptions: null
* --project: snic2017-7-196
- Ignore this warning: params.schema_ignore_params = "cluster-options,clusterOptions,project"
```

In my testing everything still works as expected, but the lint warnings are still triggered 🤔 Not sure if that's just a cache problem..?