### PR TITLE
UPPMAX: Allow jobs needing more memory than thin nodes, pick up cluster info through slurm

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -9,7 +9,7 @@ singularity {
   enabled = true
 }
 
-def hostname = "hostname".execute().text.trim()
+def hostname = "sinfo --local -N -h | head -1 | cut -f1 -d' ' ".execute().text.trim()
 
 process {
   // closure to create a suitable clusterOptions

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -9,25 +9,48 @@ singularity {
   enabled = true
 }
 
+def hostname = "hostname".execute().text.trim()
+
 process {
+  // closure to create a suitable clusterOptions
+  def clusterOptionsCreator = { m ->
+                            String base = "-A $params.project ${params.clusterOptions ?: ''}"
+			    // Do not use -p node on irma or if a thin node/core is enough
+			    if (m < 125.GB || hostname ==~ "i.*") {
+			      return base
+			    }
+			    if (m < 250.GB) {
+			      return base + " -p node -C mem256GB "
+			    }
+			    // Remaining cases use the largest available node (1 Tbyte for rackham, 512 Gbyte for others)
+			    if (hostname ==~ "r.*") {
+			      return base + " -p node -C mem1TB "
+			    }
+			    return base + " -p node -C mem512GB "
+			  }
+
+
   executor = 'slurm'
-  clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
+  clusterOptions = { clusterOptionsCreator(task.memory) }
 }
 
 params {
   save_reference = true
 
-  max_memory = 125.GB
+  max_memory = 970.GB
   max_cpus = 16
   max_time = 240.h
   // illumina iGenomes reference file paths on UPPMAX
   igenomes_base = '/sw/data/uppnex/igenomes/'
 }
 
-def hostname = "hostname".execute().text.trim()
+if (hostname ==~ "b.*") {
+  params.max_memory = 500.GB
+}
 
-if (hostname ==~ "b.*" || hostname ==~ "s.*") {
-  params.max_memory = 109.GB
+if (hostname ==~ "s.*") {
+  params.max_memory = 500.GB
+  params.max_time = 700.h
 }
 
 if (hostname ==~ "i.*") {


### PR DESCRIPTION
Use slurm to find a node from the correct cluster rather than relying on hostname (support case of login nodes for rackham being used for snowy and snowy being accessed with `SLURM_CLUSTERS=snowy`).

Raise `max_memory` to the largest node on the specific cluster.

Add handling to modify the sbatch directives as needed if more memory is required than is supported on a single node.

See also #220.


I've tried verifying this as far as I can, but that is a fairly limited degree, so both scrutiny and practical testing would be very welcome.