### PR TITLE
Add TMPDIR and mount for it to singularity configuration + Migrate to BioinformaticsResources for genomes.

### DIFF
--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -31,7 +31,7 @@ process {
 params {
   saveReference = true
   // iGenomes reference base
-  igenomes_base = '/exports/igmm/eddie/NextGenResources/igenomes'
+  igenomes_base = '/exports/igmm/eddie/BioinformaticsResources/igenomes'
   max_memory = 384.GB
   max_cpus = 32
   max_time = 240.h
@@ -42,8 +42,8 @@ env {
 }
 
 singularity {
-  envWhitelist = "SINGULARITY_TMPDIR"
-  runOptions = '-p'
+  envWhitelist = "SINGULARITY_TMPDIR,TMPDIR"
+  runOptions = '-p -B "$TMPDIR"'
   enabled = true
   autoMounts = true
 }


### PR DESCRIPTION
This config update is intended to affect only the University of Edinburgh eddie cluster configuration.
It fixes an issue with /tmp filling up when using singularity because:

- TMPDIR isn't set inside the container environment
- mktemp therefore defaults to /tmp inside the container
- Singularity on eddie has been configured to mount /tmp inside the container

/tmp is tiny on eddie nodes, so this causes issues.

It also migrates ot using BioinformaticsResources rather than the deprecated NextGenResources.