### PR TITLE
cbe: send SIGUSR2 upon job termination

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -8,8 +8,10 @@ params {
 process {
   executor = 'slurm'
   queue = { task.memory <= 170.GB ? 'c' : 'm' }
-  clusterOptions = { def qos = task.time <= 1.h ? '--qos rapid' : { task.time <= 8.h ? '--qos short': { task.time <= 48.h ? '--qos medium' : '--qos long' } }; qos << ' --signal B:USR2' }  
   module = 'anaconda3/2019.10'
+  
+  // --signal option will be handled by nextflow after 21.10.0 release (see https://github.com/nextflow-io/nextflow/issues/2163)
+  clusterOptions = { '--signal B:USR2 ' << ( task.time <= 1.h ? '--qos rapid' : ( task.time <= 8.h ? '--qos short': ( task.time <= 48.h ? '--qos medium' : '--qos long' ) ) ) }
 }
 
 singularity {

--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -8,7 +8,7 @@ params {
 process {
   executor = 'slurm'
   queue = { task.memory <= 170.GB ? 'c' : 'm' }
-  clusterOptions = { task.time <= 1.h ? '--qos rapid' : task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
+  clusterOptions = { def qos = task.time <= 1.h ? '--qos rapid' : { task.time <= 8.h ? '--qos short': { task.time <= 48.h ? '--qos medium' : '--qos long' } }; qos << ' --signal B:USR2' }  
   module = 'anaconda3/2019.10'
 }
 

--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -22,6 +22,6 @@ singularity {
 params {
   params.max_time = 14.d
   params.max_cpus = 36
-  params.max_memory = 4.TB
+  params.max_memory = 1800.GB
   igenomes_base = '/resources/references/igenomes'
 }

--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -11,7 +11,7 @@ process {
   module = 'anaconda3/2019.10'
   
   // --signal option will be handled by nextflow after 21.10.0 release (see https://github.com/nextflow-io/nextflow/issues/2163)
-  clusterOptions = { '--signal B:USR2 ' << ( task.time <= 1.h ? '--qos rapid' : ( task.time <= 8.h ? '--qos short': ( task.time <= 48.h ? '--qos medium' : '--qos long' ) ) ) }
+  clusterOptions = { '--signal B:USR2 ' << ( (queue == 'c' & task.time <= 1.h) ? '--qos rapid' : ( task.time <= 8.h ? '--qos short': ( task.time <= 48.h ? '--qos medium' : '--qos long' ) ) ) }
 }
 
 singularity {


### PR DESCRIPTION
Previously, if a process hit the walltime limit and received `SIGKILL` from the slurm scheduler, singularity did not properly propagate such (soft) kill signal.
This prevented the exit code to be caught, e.g for resubmission purposes.

This commit introduces a workaround using slurms `--signal` directive to send `SIGUSR2` to the singularity process itself (instead of container child processes, which presumably was happening before).
Effectively, once a job reaches walltime limit, this will result in exitcode 140 which is typically caught by the `errorStrategy` in nf-core pipelines

See also:
https://slurm.schedmd.com/sbatch.html#OPT_signal
https://github.com/nextflow-io/nextflow/issues/2163
https://github.com/nextflow-io/nextflow/issues/1561