### PR TITLE
Computerome

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
             - 'ccga_med'
             - 'cfc'
             - 'cfc_dev'
+            - 'computerome'
             - 'crick'
             - 'denbi_qbic'
             - 'ebc'

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Currently documentation is available for the following systems:
 * [CCGA_DX](docs/ccga_dx.md)
 * [CCGA_MED](docs/ccga_med.md)
 * [CFC](docs/cfc.md)
+* [Computerome](docs/computerome.md)
 * [CRICK](docs/crick.md)
 * [CZBIOHUB_AWS](docs/czbiohub.md)
 * [DENBI_QBIC](docs/denbi_qbic.md)

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -1,0 +1,26 @@
+singularityDir = "/gpfs/scratch/${USER}/singularity_images_nextflow"
+
+//Profile config names for nf-core/configs
+params {
+  config_profile_description = 'Computerome 2.0 cluster profile provided by nf-core/configs.'
+  config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
+  config_profile_url = 'https://www.computerome.dk/'
+}
+
+singularity {
+  enabled = true
+  autoMounts = true
+  cacheDir = singularityDir
+}
+
+process {
+  beforeScript = 'module load singularity squashfs-tools'
+  executor = 'pbs'
+  queue = { task.memory >= 192.GB ? 'fatnode': 'thinnode'}
+}
+
+params {
+  max_memory = 1500.GB
+  max_cpus = 40
+  max_time = 168.h
+}

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,7 +4,7 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
-  schema_ignore_params = "project,genomes,cache_dir,modules"
+  schema_ignore_params = "project,cache_dir"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 
@@ -12,8 +12,9 @@ params {
   
   //There is no max walltime on the cluster, but a week seems sensible if not directly specified
   max_time = 168.h 
+  
+  cache_dir = "/home/projects/$params.project/scratch"
 }
-params.cache_dir = "/home/projects/$params.project/scratch"
 
 singularity {
   enabled = true

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,6 +4,7 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
+  params.schema_ignore_params = "project"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,6 +4,7 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
+  cache_dir = "/home/projects/$params.project/scratch"
   schema_ignore_params = "project,cache_dir"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
@@ -12,8 +13,6 @@ params {
   
   //There is no max walltime on the cluster, but a week seems sensible if not directly specified
   max_time = 168.h 
-  
-  cache_dir = "/home/projects/$params.project/scratch"
 }
 
 singularity {

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -5,7 +5,7 @@ params {
   config_profile_url = 'https://www.computerome.dk/'
   project = null
   schema_ignore_params = "project"
-  cache = { "/home/projects/$params.project/scratch" }
+  cache_dir = { "/home/projects/$params.project/scratch" }
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 
@@ -18,11 +18,11 @@ params {
 singularity {
   enabled = true
   autoMounts = true
-  cacheDir = params.cache
+  cacheDir = params.cache_dir
 }
 
 process {
-  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=$params.cache; export NXF_SINGULARITY_CACHEDIR=$params.cache" }
+  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=$params.cache_dir; export NXF_SINGULARITY_CACHEDIR=$params.cache_dir" }
   executor = 'pbs'
   queueSize = 2000
   clusterOptions = { "-A $params.project -W group_list=$params.project" }

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -1,5 +1,3 @@
-singularityDir = "/scratch/${USER}/singularity_images_nextflow"
-
 //Profile config names for nf-core/configs
 params {
   config_profile_description = 'Computerome 2.0 cluster profile provided by nf-core/configs.'
@@ -10,7 +8,6 @@ params {
 singularity {
   enabled = true
   autoMounts = true
-  cacheDir = singularityDir
 }
 
 process {

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -13,7 +13,7 @@ params {
   //There is no max walltime on the cluster, but a week seems sensible if not directly specified
   max_time = 168.h 
 }
-params.cache_dir = { "/home/projects/$params.project/scratch" }
+params.cache_dir = "/home/projects/$params.project/scratch"
 
 singularity {
   enabled = true
@@ -22,8 +22,8 @@ singularity {
 }
 
 process {
-  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=$params.cache_dir; export NXF_SINGULARITY_CACHEDIR=$params.cache_dir" }
+  beforeScript = "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=$params.cache_dir"
   executor = 'pbs'
   queueSize = 2000
-  clusterOptions = { "-A $params.project -W group_list=$params.project" }
+  clusterOptions = "-A $params.project -W group_list=$params.project"
 } 

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -5,9 +5,9 @@ params {
   config_profile_url = 'https://www.computerome.dk/'
   project = null
   
-  max_memory = 1500.GB
+  max_memory = 1500.GB #Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_cpus = 40
-  max_time = 168.h
+  max_time = 168.h #There is no max walltime on the cluster, but a week seems sensible if not directly specified
 }
 
 singularity {
@@ -19,5 +19,6 @@ singularity {
 process {
   beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=/home/projects/$params.project/scratch" }
   executor = 'pbs'
+  queueSize = 2000
   clusterOptions = { "-A $params.project -W group_list=$params.project" }
 }

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,7 +4,7 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
-  params.schema_ignore_params = "project"
+  schema_ignore_params = "project"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -8,6 +8,7 @@ params {
 singularity {
   enabled = true
   autoMounts = true
+  cacheDir = './scratch'
 }
 
 process {

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -5,9 +5,12 @@ params {
   config_profile_url = 'https://www.computerome.dk/'
   project = null
   
-  max_memory = 1500.GB #Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
+  //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
+  max_memory = 1500.GB 
   max_cpus = 40
-  max_time = 168.h #There is no max walltime on the cluster, but a week seems sensible if not directly specified
+  
+  //There is no max walltime on the cluster, but a week seems sensible if not directly specified
+  max_time = 168.h 
 }
 
 singularity {
@@ -21,4 +24,4 @@ process {
   executor = 'pbs'
   queueSize = 2000
   clusterOptions = { "-A $params.project -W group_list=$params.project" }
-}
+} 

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,6 +4,10 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
+  
+  max_memory = 1500.GB
+  max_cpus = 40
+  max_time = 168.h
 }
 
 singularity {
@@ -16,10 +20,4 @@ process {
   beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=/home/projects/$params.project/scratch" }
   executor = 'pbs'
   clusterOptions = { "-A $params.project -W group_list=$params.project" }
-}
-
-params {
-  max_memory = 1500.GB
-  max_cpus = 40
-  max_time = 168.h
 }

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -5,7 +5,7 @@ params {
   config_profile_url = 'https://www.computerome.dk/'
   project = null
   schema_ignore_params = "project"
-  singularity_cache_dir = { "/home/projects/$params.project/scratch" }
+  cache = { "/home/projects/$params.project/scratch" }
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 
@@ -18,11 +18,11 @@ params {
 singularity {
   enabled = true
   autoMounts = true
-  cacheDir = params.singularity_cache_dir
+  cacheDir = params.cache
 }
 
 process {
-  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=/home/projects/$params.project/scratch" }
+  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=$params.cache; export NXF_SINGULARITY_CACHEDIR=$params.cache" }
   executor = 'pbs'
   queueSize = 2000
   clusterOptions = { "-A $params.project -W group_list=$params.project" }

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -3,17 +3,19 @@ params {
   config_profile_description = 'Computerome 2.0 cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
+  project = null
 }
 
 singularity {
   enabled = true
   autoMounts = true
-  cacheDir = './scratch'
+  cacheDir = { "/home/projects/$params.project/scratch" }
 }
 
 process {
-  beforeScript = 'module load tools singularity/3.8.0'
+  beforeScript = { "module load tools singularity/3.8.0; export _JAVA_OPTIONS=-Djava.io.tmpdir=/home/projects/$params.project/scratch" }
   executor = 'pbs'
+  clusterOptions = { "-A $params.project -W group_list=$params.project" }
 }
 
 params {

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -1,4 +1,4 @@
-singularityDir = "/gpfs/scratch/${USER}/singularity_images_nextflow"
+singularityDir = "/scratch/${USER}/singularity_images_nextflow"
 
 //Profile config names for nf-core/configs
 params {
@@ -14,7 +14,7 @@ singularity {
 }
 
 process {
-  beforeScript = 'module load singularity squashfs-tools'
+  beforeScript = 'module load tools singularity/3.8.0'
   executor = 'pbs'
   queue = { task.memory >= 192.GB ? 'fatnode': 'thinnode'}
 }

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -4,8 +4,7 @@ params {
   config_profile_contact = 'Marc Trunjer Kusk Nielsen (@marcmtk)'
   config_profile_url = 'https://www.computerome.dk/'
   project = null
-  schema_ignore_params = "project"
-  cache_dir = { "/home/projects/$params.project/scratch" }
+  schema_ignore_params = "project,genomes,cache_dir,modules"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 
@@ -14,6 +13,7 @@ params {
   //There is no max walltime on the cluster, but a week seems sensible if not directly specified
   max_time = 168.h 
 }
+params.cache_dir = { "/home/projects/$params.project/scratch" }
 
 singularity {
   enabled = true

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -5,6 +5,7 @@ params {
   config_profile_url = 'https://www.computerome.dk/'
   project = null
   schema_ignore_params = "project"
+  singularity_cache_dir = { "/home/projects/$params.project/scratch" }
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 
@@ -17,7 +18,7 @@ params {
 singularity {
   enabled = true
   autoMounts = true
-  cacheDir = { "/home/projects/$params.project/scratch" }
+  cacheDir = params.singularity_cache_dir
 }
 
 process {

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -16,7 +16,6 @@ singularity {
 process {
   beforeScript = 'module load tools singularity/3.8.0'
   executor = 'pbs'
-  queue = { task.memory >= 192.GB ? 'fatnode': 'thinnode'}
 }
 
 params {

--- a/docs/computerome.md
+++ b/docs/computerome.md
@@ -1,7 +1,5 @@
 # nf-core/configs: Computerome 2.0 Configuration
 
-This is a first attempt at creating a profile for the Computerome 2.0 cluster.
-
 To use, run the pipeline with `-profile computerome`. This will download and launch the [`computerome.config`](../conf/computerome.config) which has been pre-configured with a setup suitable for the Computerome cluster.
 
 ## Using the Computerome config profile

--- a/docs/computerome.md
+++ b/docs/computerome.md
@@ -4,4 +4,27 @@ This is a first attempt at creating a profile for the Computerome 2.0 cluster.
 
 To use, run the pipeline with `-profile computerome`. This will download and launch the [`computerome.config`](../conf/computerome.config) which has been pre-configured with a setup suitable for the Computerome cluster.
 
->NB: You will need an account to use the HPC cluster Computerome in order to run the pipeline. If in doubt contact IT.
+## Using the Computerome config profile
+
+Before running the pipeline you will need to load `Nextflow` using the environment module system (this can be done with e.g. `module load tools Nextflow/<VERSION>` where `VERSION` is e.g. `20.10`).
+
+To use, run the pipeline with `-profile computerome` (one hyphen).
+This will download and launch the [`computerome.config`](../conf/computerome.config) which has been pre-configured with a setup suitable for the Computerome servers.
+It will enable `Nextflow` to manage the pipeline jobs via the `Torque` job scheduler.
+Using this profile, `Singularity` image(s) containing required software(s) will be downloaded before execution of the pipeline.
+
+Recent version of `Nextflow` also support the environment variable `NXF_SINGULARITY_CACHEDIR` which can be used to supply images. The computerome configuration uses your project's scratch folder as the cachedir if not specified.
+
+In addition to this config profile, you will also need to specify a Computerome project id.
+You can do this with the `--project` flag (two hyphens) when launching `Nextflow`.
+For example:
+
+```bash
+# Launch a nf-core pipeline with the computerome profile for the project id ab00002
+$ nextflow run nf-core/<PIPELINE> -profile computerome --project ab00002 [...]
+```
+
+> NB: If you're not sure what your Computerome project ID is, try running `groups`.
+
+Remember to use `-bg` to launch `Nextflow` in the background, so that the pipeline doesn't exit if you leave your terminal session.
+Alternatively, you can also launch `Nextflow` in a `screen` or a `tmux` session.

--- a/docs/computerome.md
+++ b/docs/computerome.md
@@ -28,3 +28,13 @@ $ nextflow run nf-core/<PIPELINE> -profile computerome --project ab00002 [...]
 
 Remember to use `-bg` to launch `Nextflow` in the background, so that the pipeline doesn't exit if you leave your terminal session.
 Alternatively, you can also launch `Nextflow` in a `screen` or a `tmux` session.
+
+## About Computerome 2.0
+
+The Danish National Supercomputer for Life Sciences (a.k.a. Computerome) is installed at the DTU National Lifescience Center at Technical University of Denmark.
+
+The computer hardware is funded with grants from Technical University of Denmark (DTU), University of Copenhagen (KU) and Danish e-infrastructure Cooperation (DeiC) - also, it is the official Danish ELIXIR Node.
+
+Computerome 1.0 was opened in November 2014 at #121 on TOP500 Supercomputing Sites.
+
+The current setup, Computerome 2.0, was opened in 2019. It's compute resources consists of 31760 CPU cores with 210 TeraBytes of memory, connected to 17 PetaBytes of High-performance storage,

--- a/docs/computerome.md
+++ b/docs/computerome.md
@@ -1,0 +1,7 @@
+# nf-core/configs: Computerome 2.0 Configuration
+
+This is a first attempt at creating a profile for the Computerome 2.0 cluster.
+
+To use, run the pipeline with `-profile computerome`. This will download and launch the [`computerome.config`](../conf/computerome.config) which has been pre-configured with a setup suitable for the Computerome cluster.
+
+>NB: You will need an account to use the HPC cluster Computerome in order to run the pipeline. If in doubt contact IT.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -23,6 +23,7 @@ profiles {
   ccga_med     { includeConfig "${params.custom_config_base}/conf/ccga_med.config" }
   cfc          { includeConfig "${params.custom_config_base}/conf/cfc.config" }
   cfc_dev      { includeConfig "${params.custom_config_base}/conf/cfc_dev.config" }
+  computerome  { includeConfig "${params.custom_config_base}/conf/computerome.config" }
   crick        { includeConfig "${params.custom_config_base}/conf/crick.config" }
   czbiohub_aws { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
   denbi_qbic   { includeConfig "${params.custom_config_base}/conf/denbi_qbic.config" }


### PR DESCRIPTION
Adding an institutional profile for [Computerome](https://www.computerome.dk/) a Danish supercomputer for life sciences. 

I've followed the guide from [Bytesize 10](https://nf-co.re/events/2021/bytesize-10-institutional-profiles) and have tested using nf-core/viralrecon with either of `-c` or `-profile computerome --custom_config_base` syntax.

As computerome requires PBS -A and -W tags to be set i've followed the example of the uppmax configuration file and introduced a params.project. Jobs will fail if it is not set, but they only fail upon first submitting a job to the scheduler. It would be nice if it could fail faster, but i don't know how that would be done. 