### PR TITLE
update sanger profile so that long jobs to be submitted to the long queue

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -15,6 +15,9 @@ process{
   queue = 'normal'
   errorStrategy = { task.attempt <= 5 ? "retry" : "finish" }
   process.maxRetries = 5
+  withLabel:process_long {
+    queue = 'long'
+  }
 }
 
 executor{


### PR DESCRIPTION
simple config update to submit taks with `process_long` label to LSF long queue