### PR TITLE
Make memory checks use closed intervals

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -24,11 +24,11 @@ try {
 def clusterOptionsCreator = { m ->
     String base = "-A $params.project ${params.clusterOptions ?: ''}"
     // Do not use -p node on irma or if a thin node/core is enough
-    if (m < 125.GB || hostname ==~ "i.*") {
+    if (m <= 125.GB || hostname ==~ "i.*") {
         return base
     }
 
-    if (m < 250.GB) {
+    if (m <= 250.GB) {
         return base + " -p node -C mem256GB "
     }
 


### PR DESCRIPTION
Requesting e.g. 250 Gbyte should not require a 512 Gbyte node (or 125 Gbyte a 256 Gbyte).

Addresses part of https://github.com/nf-core/configs/issues/291.