### PR TITLE
UPPMAX profile - minor tweaks

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -65,7 +65,7 @@ process {
 // Cluster: Snowy
 //   Caution: Bianca nodes will be project name-nodenumber, e.g. sens2021500-001
 //   so cannot rely on just starting with 's'
-if (hostname ==~ "s[0-9][0-9]*") {
+if (hostname.matches("^s[0-9][0-9]*")) {
   params.max_time = 700.h
   params.max_memory = 3880.GB
   params.config_profile_description = 'UPPMAX (Snowy) cluster profile provided by nf-core/configs.'

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -1,12 +1,14 @@
 // UPPMAX Config Profile
 params {
-  config_profile_description = 'UPPMAX (Rackham/Bianca) cluster profile provided by nf-core/configs.'
+  // Description is overwritten for other clusters below
+  config_profile_description = 'UPPMAX (Bianca) cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'
   project = null
   clusterOptions = null
   schema_ignore_params = "genomes,input_paths,cluster-options,clusterOptions,project"
   save_reference = true
+  // Defaults set for Bianca - other clusters set below
   max_memory = 500.GB
   max_cpus = 16
   max_time = 240.h
@@ -60,22 +62,32 @@ process {
   scratch = '$SNIC_TMP'
 }
 
-if (hostname.startsWith("s")) {
+// Cluster: Snowy
+//   Caution: Bianca nodes will be project name-nodenumber, e.g. sens2021500-001
+//   so cannot rely on just starting with 's'
+if (hostname ==~ "s[0-9][0-9]*") {
   params.max_time = 700.h
   params.max_memory = 3880.GB
   params.config_profile_description = 'UPPMAX (Snowy) cluster profile provided by nf-core/configs.'
 }
 
+// Cluster: Irma
 if (hostname.startsWith("i")) {
   params.max_memory = 250.GB
   params.config_profile_description = 'UPPMAX (Irma) cluster profile provided by nf-core/configs.'
 }
 
+// Cluster: Rackham
 if (hostname.startsWith("r")) {
   params.max_cpus = 20
   params.max_memory = 970.GB
+  params.config_profile_description = 'UPPMAX (Rackham) cluster profile provided by nf-core/configs.'
 }
 
+// Cluster: Bianca - set in initial params block above
+
+// Additional devel profile for running in devel queue
+// Run with `-profile upppmax,devel`
 profiles {
   devel {
     params {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -1,6 +1,6 @@
 // UPPMAX Config Profile
 params {
-  config_profile_description = 'UPPMAX (Rackham) cluster profile provided by nf-core/configs.'
+  config_profile_description = 'UPPMAX (Rackham/Bianca) cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'
   project = null

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -1,11 +1,17 @@
-// Profile config names for nf-core/configs
+// UPPMAX Config Profile
 params {
-  config_profile_description = 'Swedish UPPMAX cluster profile provided by nf-core/configs.'
+  config_profile_description = 'UPPMAX (Rackham) cluster profile provided by nf-core/configs.'
   config_profile_contact = 'Phil Ewels (@ewels)'
   config_profile_url = 'https://www.uppmax.uu.se/'
   project = null
   clusterOptions = null
   schema_ignore_params = "genomes,input_paths,cluster-options,clusterOptions,project"
+  save_reference = true
+  max_memory = 500.GB
+  max_cpus = 16
+  max_time = 240.h
+  // illumina iGenomes reference file paths on UPPMAX
+  igenomes_base = '/sw/data/igenomes/'
 }
 
 singularity {
@@ -15,7 +21,7 @@ singularity {
 
 def hostname = "r1"
 try {
-    hostname = "sinfo --local -N -h | grep -F -v CLUSTER: | head -1 | cut -f1 -d' ' ".execute().text.trim()
+    hostname = "sinfo --local -N -h | grep -m 1 -F -v CLUSTER: | cut -f1 -d' ' ".execute().text.trim()
 } catch (java.io.IOException e) {
     System.err.println("WARNING: Could not run sinfo to determine current cluster, defaulting to rackham")
 }
@@ -24,7 +30,7 @@ try {
 def clusterOptionsCreator = { m ->
     String base = "-A $params.project ${params.clusterOptions ?: ''}"
     // Do not use -p node on irma or if a thin node/core is enough
-    if (m <= 125.GB || hostname ==~ "i.*") {
+    if (m <= 125.GB || hostname.startsWith("i")) {
         return base
     }
 
@@ -34,7 +40,7 @@ def clusterOptionsCreator = { m ->
 
 
     // Use mem1TB for remaining cases on rackham (no 512 Gbyte nodes)
-    if (hostname ==~ "r.*") {
+    if (hostname.startsWith("r")) {
         return base + " -p node -C mem1TB "
     }
 
@@ -54,26 +60,18 @@ process {
   scratch = '$SNIC_TMP'
 }
 
-params {
-  save_reference = true
-
-  max_memory = 500.GB
-  max_cpus = 16
-  max_time = 240.h
-  // illumina iGenomes reference file paths on UPPMAX
-  igenomes_base = '/sw/data/igenomes/'
-}
-
-if (hostname ==~ "s[0-9][0-9]*") {
+if (hostname.startsWith("s")) {
   params.max_time = 700.h
   params.max_memory = 3880.GB
+  params.config_profile_description = 'UPPMAX (Snowy) cluster profile provided by nf-core/configs.'
 }
 
-if (hostname ==~ "i.*") {
+if (hostname.startsWith("i")) {
   params.max_memory = 250.GB
+  params.config_profile_description = 'UPPMAX (Irma) cluster profile provided by nf-core/configs.'
 }
 
-if (hostname ==~ "r.*") {
+if (hostname.startsWith("r")) {
   params.max_cpus = 20
   params.max_memory = 970.GB
 }


### PR DESCRIPTION
* Only one `params` block instead of two
* Return only one `grep` result and don't pipe to `head`
* Use `.startsWith()` instead of regex matching (shouldn't make any difference but is harder to mess up)
* Print detected cluster name in the profile description

Not sure if any of these changes will fix the issues we've seen in #291, but I figure that they're probably all sensible tweaks anyway.