### PR TITLE
Added memory & cluster options specification for eddie sarek config

### DIFF
--- a/conf/pipeline/sarek/eddie.config
+++ b/conf/pipeline/sarek/eddie.config
@@ -2,6 +2,8 @@ process {
 
   withName:MapReads {
     cpus = 16
+    memory = 128.GB
+    clusterOptions = {"-l h_vmem=${(task.memory + 8.GB).bytes/task.cpus}"}
   }
   withName:BuildDict {
     cpus = 1


### PR DESCRIPTION
Running Sarek 2.7.1 with -profile test,eddie on University of Edinburgh cluster was failing on MapReads. Fixed with additional specification of memory and clusterOptions as per other processes.