### PR TITLE
Add UAB Cheaha profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
             - 'ccga_med'
             - 'cfc'
             - 'cfc_dev'
+            - 'cheaha'
             - 'computerome'
             - 'crick'
             - 'denbi_qbic'

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Currently documentation is available for the following systems:
 * [CCGA_DX](docs/ccga_dx.md)
 * [CCGA_MED](docs/ccga_med.md)
 * [CFC](docs/cfc.md)
+* [CHEAHA](docs/cheaha.md)
 * [Computerome](docs/computerome.md)
 * [CRICK](docs/crick.md)
 * [CZBIOHUB_AWS](docs/czbiohub.md)

--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -18,7 +18,7 @@ process {
 }
 
 params {
-    max_memory = 510.GB
+    max_memory = 750.GB
     max_cpus = 128
     max_time = 150.h
 }

--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -7,12 +7,12 @@ params {
 
 singularity {
     enabled = true
-    automounts = true
+    autoMounts = true
 }
 
 process {
     executor = 'slurm'
-    queue = { task.memory <= 50GB ? (task.time <= 2.h ? 'express' : task.time <= 12.h ? 'short' : task.time <= 50.h ? 'medium' : 'long') : (task.time <= 50.h ? 'largemem' : 'largemem-long')}
+    queue = { task.memory <= 50.GB ? (task.time <= 2.h ? 'express' : task.time <= 12.h ? 'short' : task.time <= 50.h ? 'medium' : 'long') : (task.time <= 50.h ? 'largemem' : 'largemem-long')}
     maxRetries = 3
     beforeScript = 'module load Singularity'
 }

--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -1,0 +1,24 @@
+params {
+    config_profile_name = 'cheaha'
+    config_profile_description = 'University of Alabama at Birmingham Cheaha HPC'
+    config_profile_contact = 'Lara Ianov (lianov@uab.edu) or Austyn Trull (atrull@uab.edu)'
+    config_profile_url = 'https://www.uab.edu/cores/ircp/bds'
+}
+
+singularity {
+    enabled = true
+    automounts = true
+}
+
+process {
+    executor = 'slurm'
+    queue = { task.memory <= 50GB ? (task.time <= 2.h ? 'express' : task.time <= 12.h ? 'short' : task.time <= 50.h ? 'medium' : 'long') : (task.time <= 50.h ? 'largemem' : 'largemem-long')}
+    maxRetries = 3
+    beforeScript = 'module load Singularity'
+}
+
+params {
+    max_memory = 510.GB
+    max_cpus = 128
+    max_time = 150.h
+}

--- a/docs/cheaha.md
+++ b/docs/cheaha.md
@@ -16,4 +16,17 @@ module load Nextflow
 All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
 
 >NB: You will need an account to use the HPC cluster on Cheaha in order to run the pipeline. If in doubt contact UAB IT Research Computing.
->NB: Nextflow will need to submit the jobs via SLURM to the HPC cluster and as such the commands above will have to be executed on one of the login nodes. If in doubt contact UAB IT Research Computing.
+
+>NB: Nextflow will need to submit the jobs via SLURM to the HPC cluster and as such the commands above will have to be executed on one of the login nodes (or alternatively in an interactive partition, but be aware of time limit). If in doubt contact UAB IT Research Computing.
+
+>NB: Instead of using `module load Nextflow`, you may instead create a conda environment (e.g: `conda create -p $USER_DATA/nf-core_nextflow_env nf-core nextflow`) if you would like to have a more personalized environment of Nextflow (versions which may not be modules yet) and nf-core tools. This __requires__ you to instead do the following:
+
+```bash
+module purge
+module load Singularity
+module load Anaconda3
+# change path/enviroment name if according to what you created
+conda activate $USER_DATA/nf-core_nextflow_env 
+```
+
+>NB: while the jobs for each process of the pipeline are sent to the appropriate nodes, the current session must remain active while the pipeline is running. We recommend to use `screen` prior to loading any modules/environments. Once the pipeline starts you can detach the screen session by typing `Ctrl-a d` so you can safely logout of HPC, while keeping the pipeline active (and you may resume the screen session with `screen -r`). Other similar tools (e.g. `tmux`) may also be used.

--- a/docs/cheaha.md
+++ b/docs/cheaha.md
@@ -1,0 +1,19 @@
+# nf-core/configs: Cheaha (UAB HPC) Configuration
+
+All nf-core pipelines have been successfully configured for use on the Cheaha HPC cluster at the [The University of Alabama at Birmingham](https://www.uab.edu/home/).
+
+To use, run the pipeline with `-profile cheaha`. This will download and launch the [`cheaha.config`](../conf/cheaha.config) which has been pre-configured with a setup suitable for the Cheaha HPC cluster. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
+
+Before running the pipeline you will need to load Singularity and Nextflow using the environment module system on Cheaha. You can do this by issuing the commands below:
+
+```bash
+## Singularity environment modules
+module purge
+module load Singularity
+module load Nextflow
+```
+
+All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
+
+>NB: You will need an account to use the HPC cluster on Cheaha in order to run the pipeline. If in doubt contact UAB IT Research Computing.
+>NB: Nextflow will need to submit the jobs via SLURM to the HPC cluster and as such the commands above will have to be executed on one of the login nodes. If in doubt contact UAB IT Research Computing.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -25,6 +25,7 @@ profiles {
   ccga_med     { includeConfig "${params.custom_config_base}/conf/ccga_med.config" }
   cfc          { includeConfig "${params.custom_config_base}/conf/cfc.config" }
   cfc_dev      { includeConfig "${params.custom_config_base}/conf/cfc_dev.config" }
+  cheaha       { includeConfig "${params.custom_config_base}/conf/cheaha.config" }
   computerome  { includeConfig "${params.custom_config_base}/conf/computerome.config" }
   crick        { includeConfig "${params.custom_config_base}/conf/crick.config" }
   czbiohub_aws { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }


### PR DESCRIPTION
Request to add profile for the UAB HPC cluster, Cheaha.

All required changes are present in this request (`cheaha.md` added to `docs`, `cheaha.conf` added to `conf`, profile added to `nfcore_custom.config` and profile added to `README.md`).

The configuration has been tested with the rnaseq and nanoseq pipelines.

Contributors to profile, review and tests are Austyn Trull (@atrull314) and Lara Ianov (@lianov).