### PR TITLE
Added ARTIC v4.1 primer set information

### DIFF
--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -51,6 +51,12 @@ params {
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4/SARS-CoV-2.scheme.bed'
             scheme     = 'SARS-CoV-2'
           }
+          '4.1' {
+            fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.reference.fasta'
+            gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+            primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.scheme.bed'
+            scheme     = 'SARS-CoV-2'
+          }          
           '1200' {
             fasta      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/primer_schemes/artic/nCoV-2019/V1200/nCoV-2019.reference.fasta'
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'


### PR DESCRIPTION
ARTIC v4.1 has been recommended to improve sequencing performance on Omicron samples [1], and including information regarding the v4.1 primer set (obtained from [2]) will be convenient for the users of nf-core/viralrecon. Thank you.

[1] https://www.ecdc.europa.eu/sites/default/files/documents/Methods-for-the-detection-and-characterisation-of-SARS-CoV-2-variants-first-update.pdf
[2] https://github.com/artic-network/artic-ncov2019/tree/master/primer_schemes/nCoV-2019/V4.1