### PR TITLE
Update mpcdf.config

### DIFF
--- a/conf/mpcdf.config
+++ b/conf/mpcdf.config
@@ -61,7 +61,7 @@ profiles {
        
         params {
             config_profile_description = 'MPCDF raven profile (unofficially) provided by nf-core/configs.'
-            max_memory = 368.GB
+            max_memory = 120000.MB
             max_cpus = 72
             max_time = 24.h
         }


### PR DESCRIPTION
Update max_memory to 120.GB (in MB) to match the resources allowed on the raven cluster.