### PR TITLE
modified mpcdf configs (general + eager)

### DIFF
--- a/conf/mpcdf.config
+++ b/conf/mpcdf.config
@@ -47,7 +47,7 @@ profiles {
         }
        
         executor {
-            queueSize = 8
+            queueSize = 72
             pollInterval = '1 min'
             queueStatInterval = '5 min'
         }
@@ -61,7 +61,7 @@ profiles {
        
         params {
             config_profile_description = 'MPCDF raven profile (unofficially) provided by nf-core/configs.'
-            max_memory = 368.GB
+            max_memory = 2048.GB
             max_cpus = 72
             max_time = 24.h
         }

--- a/conf/pipeline/eager/mpcdf.config
+++ b/conf/pipeline/eager/mpcdf.config
@@ -61,4 +61,59 @@ process {
    }
   }
   }
+raven {
+// Specific nf-core/eager process configuration
+process {
+
+  withName: malt {
+    maxRetries = 1
+    memory = 2048.GB
+    cpus = 72
+    time = 24.h
+  }
+  
+  withLabel:'sc_tiny'{
+    cpus = { check_max( 1, 'cpus' ) }
+    memory = { check_max( 1.GB * task.attempt, 'memory' ) }
+    time = 24.h
+  }
+
+  withLabel:'sc_small'{
+    cpus = { check_max( 1, 'cpus' ) }
+    memory = { check_max( 4.GB * task.attempt, 'memory' ) }
+    time = 24.h
+  }
+
+  withLabel:'sc_medium'{
+    cpus = { check_max( 1, 'cpus' ) }
+    memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+    time = 24.h
+  }
+
+  withLabel:'mc_small'{
+    cpus = { check_max( 2 * task.attempt, 'cpus' ) }
+    memory = { check_max( 4.GB * task.attempt, 'memory' ) }
+    time = 24.h
+  }
+
+  withLabel:'mc_medium' {
+    cpus = { check_max( 4 * task.attempt, 'cpus' ) }
+    memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+    time = 24.h
+  }
+
+  withLabel:'mc_large'{
+     cpus = { check_max( 8 * task.attempt, 'cpus' ) }
+     memory = { check_max( 16.GB * task.attempt, 'memory' ) }
+     time = 24.h
+  }
+
+  withLabel:'mc_huge'{
+     cpus = { check_max( 72, 'cpus' ) }
+     memory = { check_max( 240.GB * task.attempt, 'memory' ) }
+     time = 24.h
+   }
+  }
+  }
+
 }


### PR DESCRIPTION
changed config file for mpcdf raven (general to be 2048 GB max mem, and 72 CPUS max) and eager with malt using the full large node and the mc_huge label changing to a full node, of comprable size to avoid shared node allocation.