### PR TITLE
Update eager @ eva to exclude slow nodes for mapping

### DIFF
--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -76,19 +76,19 @@ process {
    }
    
   withName: bwa {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bwamem {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: circularmapper {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bowtie2 {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
 
   withName: samtools_flagstat {

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -76,19 +76,19 @@ process {
    }
    
   withName: bwa {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bwamem {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: circularmapper {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bowtie2 {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory},h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
 
   withName: samtools_flagstat {

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -74,6 +74,22 @@ process {
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 2)}G" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' } 
    }
+   
+  withName: bwa {
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+  }
+  
+  withName: bwamem {
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+  }
+  
+  withName: circularmapper {
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+  }
+  
+  withName: bowtie2 {
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory} h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+  }
 
   withName: samtools_flagstat {
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 2)}G" }

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -76,19 +76,19 @@ process {
    }
    
   withName: bwa {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga())}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bwamem {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga())}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: circularmapper {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga())}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
   
   withName: bowtie2 {
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${task.memory.toGiga()}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga())}G,h=!(bionode01|bionode02|bionode03|bionode04|bionode05|bionode06)" }
   }
 
   withName: samtools_flagstat {


### PR DESCRIPTION
As discussed with Alex Hü.

Old SDAG nodes half as fast as old CDAG nodes, so exclude SDAG to speed up alignment step