### PR TITLE
Added PileupSummariesForMutect2 in CPU limit list

### DIFF
--- a/conf/munin.config
+++ b/conf/munin.config
@@ -20,7 +20,6 @@ process {
   maxForks = 46
 
 // Limit cpus for Mutect2
-process {
   withName:'Mutect2|Mutect2Single|PileupSummariesForMutect2' {
     time = {48.h * task.attempt}
     maxForks = 12

--- a/conf/munin.config
+++ b/conf/munin.config
@@ -20,9 +20,10 @@ process {
   maxForks = 46
 
 // Limit cpus for Mutect2
-  withName:'Mutect2|Mutect2Single' {
+process {
+  withName:'Mutect2|Mutect2Single|PileupSummariesForMutect2' {
     time = {48.h * task.attempt}
-    maxForks = 23
+    maxForks = 12
   }
 }
 


### PR DESCRIPTION
Add PileupSummariesForMutect2 to the list to run with less threads.
Changed the MaxForks to 12
Tested on an internal sample and it worked!

Please follow these steps before submitting your PR:

* [ ] If your PR is a work in progress, include `[WIP]` in its title
* [ ] Your PR targets the `master` branch
* [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:
* [ ] Add your custom config file to the `conf/` directory
* [ ] Add your documentation file to the `docs/` directory
* [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
* [ ] Add your custom profile to the `README.md` file in the top-level directory
* [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request from @nf-core/configs-team

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
