### PR TITLE
Fix memory issues in EVA.

### DIFF
--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -191,7 +191,7 @@ process {
    
   withName:get_software_versions {
     cache = false
-    beforeScript = '_JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx256m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
+    beforeScript = 'export _JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx256m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 2)}G" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
   }

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -381,13 +381,6 @@ profiles {
           clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 3)}G" }
           errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'ignore' }
         }
-        
-       withName:get_software_versions {
-         cache = false
-         clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 3)}G" }
-         errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
-       }
-
       }
   }
 
@@ -567,13 +560,6 @@ profiles {
           clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 6)}G" }
           errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'ignore' }
         }
-        
-       withName:get_software_versions {
-         cache = false
-         clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 6)}G" }
-         errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
-       }
-
       }
   }
 

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -192,7 +192,7 @@ process {
   withName:get_software_versions {
     cache = false
     beforeScript = 'export _JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx256m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
-    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 2)}G" }
+    clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toMega())}M" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
   }
   

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -197,11 +197,12 @@ process {
   }
   
   withName:kraken_merge {
-  beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
-}
+    beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
+  }
 
-withName:multiqc {
-  beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1;'
+  withName:multiqc {
+    beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1;'
+  }
 }
 
 profiles {

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -191,7 +191,7 @@ process {
    
   withName:get_software_versions {
     cache = false
-    beforeScript = 'export _JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx256m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
+    beforeScript = 'export _JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx512m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toMega())}M" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
   }

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -191,10 +191,17 @@ process {
    
   withName:get_software_versions {
     cache = false
+    beforeScript = '_JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx256m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toGiga() * 2)}G" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }
   }
+  
+  withName:kraken_merge {
+  beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
+}
 
+withName:multiqc {
+  beforeScript = 'export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1;'
 }
 
 profiles {


### PR DESCRIPTION
Set max heap size for java jobs in `get_software_versions`.
Limited OpenBLAS threading for python jobs that use numpy/pandas.