### PR TITLE
Update eva.config

### DIFF
--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -191,6 +191,7 @@ process {
    
   withName:get_software_versions {
     cache = false
+    clusterOptions = { "-S /bin/bash -V -l h=!(bionode06)"
     beforeScript = 'export _JAVA_OPTIONS="-XX:ParallelGCThreads=1 -Xmx512m"; export OPENBLAS_NUM_THREADS=1; export OMP_NUM_THREADS=1'
     clusterOptions = { "-S /bin/bash -V -l h_vmem=${(task.memory.toMega())}M" }
     errorStrategy = { task.exitStatus in [1,143,137,104,134,139,140] ? 'retry' : 'finish' }


### PR DESCRIPTION
Limit java heap size in `get_software_versions` process. 
Add numpy multithreading limit to python jobs using pandas/numpy.