### PR TITLE
Update retry strategy for preemptible instances on GCP

### DIFF
--- a/conf/google.config
+++ b/conf/google.config
@@ -15,7 +15,8 @@ google.zone = params.google_zone
 google.lifeSciences.debug = params.google_debug
 workDir = params.google_bucket
 google.lifeSciences.preemptible = params.google_preemptible
+
 if (google.lifeSciences.preemptible) {
-  process.errorStrategy = { task.exitStatus==14 ? 'retry' : 'terminate' }
+  process.errorStrategy = { task.exitStatus in [8,10,14] ? 'retry' : 'terminate' }
   process.maxRetries = 5
 }


### PR DESCRIPTION
As suggested in [official docs](https://cloud.google.com/life-sciences/docs/troubleshooting#retrying_after_encountering_errors)