### PR TITLE
Vsc ugent fix for job-intensive pipelines

### DIFF
--- a/conf/vsc_ugent.config
+++ b/conf/vsc_ugent.config
@@ -7,9 +7,9 @@ workDir = "$scratch_dir/work"
 // Perform work directory cleanup when the run has succesfully completed
 // cleanup = true
 
-// Reduce the job submit rate to about 10 per second, this way the server won't be bombarded with jobs
+// Reduce the job submit rate to about 5 per second, this way the server won't be bombarded with jobs
 executor {
-    submitRateLimit = '10 sec'
+    submitRateLimit = '5 sec'
 }
 
 // Specify that singularity should be used and where the cache dir will be for the images

--- a/conf/vsc_ugent.config
+++ b/conf/vsc_ugent.config
@@ -10,6 +10,7 @@ workDir = "$scratch_dir/work"
 // Reduce the job submit rate to about 5 per second, this way the server won't be bombarded with jobs
 executor {
     submitRateLimit = '5 sec'
+    queueSize = 50
 }
 
 // Specify that singularity should be used and where the cache dir will be for the images


### PR DESCRIPTION
When running a job-intensive pipeline I received this error:
```
sbatch: error: Batch job submission failed: Socket timed out on send/recv operation
```

This PR is an attempt to reduce the strain on the scheduler for these job-intensive pipelines