### PR TITLE
Add hMPX_B1 to `viralrecon/genomes.config`

### DIFF
--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -11,9 +11,9 @@ params {
     // This reference is the MonkeyPox B.1 reference currently used by https://github.com/nextstrain/monkeypox/
     // primer schemes are being developed but not finalised yet so this only supports metagenomes
     'NC_063383.1' {
-      fasta             =  'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'    
-     	gff               =  'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
-      nextclade_dataset     		   = 'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
+      fasta             =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'    
+     	gff               =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
+      nextclade_dataset     		   = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
       nextclade_dataset_reference  = 'pseudo_ON563414'
       nextclade_dataset_tag		     = '2022-06-29T12:00:00Z'
     }

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -24,11 +24,11 @@ params {
 
     'NC_063383.1' {
 
-        fasta             =  'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
+        fasta             =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
         
-     	gff               =  'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
+     	gff               =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
       
-        nextclade_dataset     		 = 'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
+        nextclade_dataset     		 = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
 
         nextclade_dataset_reference  = 'pseudo_ON563414'
 

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -24,8 +24,10 @@ params {
 
     'NC_063383.1' {
 
-        fasta             =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/2022-06-29T12h.fasta.gz'
+        fasta             =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
         
+     	gff               =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
+      
         nextclade_dataset     		 = '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
 
         nextclade_dataset_reference  = 'pseudo_ON563414'

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -1,158 +1,80 @@
 
-
 /*
-
  * -------------------------------------------------
-
  *  nfcore/viralrecon custom profile Nextflow config file
-
  * -------------------------------------------------
-
  * Defines viral reference genomes for all environments.
-
  */
 
 params {
-
   // Genome reference file paths
-
   genomes {
-
     // This reference is the MonkeyPox B.1 reference currently used by https://github.com/nextstrain/monkeypox/
-
     // primer schemes are being developed but not finalised yet so this only supports metagenomes
-
     'NC_063383.1' {
-
-        fasta             =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
-        
-     	gff               =  'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
-      
-        nextclade_dataset     		 = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
-
-        nextclade_dataset_reference  = 'pseudo_ON563414'
-
-        nextclade_dataset_tag		 = '2022-06-29T12:00:00Z'
-
+      fasta             =  'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'    
+     	gff               =  'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
+      nextclade_dataset     		   = 'https://github.com/pcjentsch/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
+      nextclade_dataset_reference  = 'pseudo_ON563414'
+      nextclade_dataset_tag		     = '2022-06-29T12:00:00Z'
     }
-
     'NC_045512.2' {
-
       // This version of the reference has been kept here for backwards compatibility.
-
       // Please use 'MN908947.3' if possible because all primer sets are available / have been pre-prepared relative to that assembly
-
       fasta            = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
-
       gff              = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.gff.gz'
-
       nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
-
       nextclade_dataset_name      = 'sars-cov-2'
-
       nextclade_dataset_reference = 'MN908947'
-
       nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
-
     }
-
     'MN908947.3' {
-
       fasta            = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.fna.gz'
-
       gff              = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
       nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
-
       nextclade_dataset_name      = 'sars-cov-2'
-
       nextclade_dataset_reference = 'MN908947'
-
       nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
-
       primer_sets {
-
         artic {
-
           '1' {
-
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V1/nCoV-2019.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V1/nCoV-2019.primer.bed'
-
             scheme     = 'nCoV-2019'
-
           }
-
           '2' {
-
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V2/nCoV-2019.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V2/nCoV-2019.primer.bed'
-
             scheme     = 'nCoV-2019'
-
           }
-
           '3' {
-
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V3/nCoV-2019.primer.bed'
-
             scheme     = 'nCoV-2019'
-
           }
-
           '4' {
-
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4/SARS-CoV-2.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4/SARS-CoV-2.scheme.bed'
-
             scheme     = 'SARS-CoV-2'
-
           }
-
           '4.1' {
-
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.scheme.bed'
-
             scheme     = 'SARS-CoV-2'
-
           }          
-
           '1200' {
-
             fasta      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/primer_schemes/artic/nCoV-2019/V1200/nCoV-2019.reference.fasta'
-
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-
             primer_bed = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/primer_schemes/artic/nCoV-2019/V1200/nCoV-2019.bed'
-
             scheme     = 'nCoV-2019'
-
           }
-
         }
-
       }
-
     }
-
   }
-
 }
-

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -24,11 +24,11 @@ params {
 
     'NC_063383.1' {
 
-        fasta             =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
+        fasta             =  'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.fasta.gz'
         
-     	gff               =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
+     	gff               =  'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.gff.gz'
       
-        nextclade_dataset     		 = '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
+        nextclade_dataset     		 = 'https://github.com/pcjentsch/test-datasets/blob/viralrecon/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
 
         nextclade_dataset_reference  = 'pseudo_ON563414'
 

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -1,70 +1,156 @@
+
+
 /*
+
  * -------------------------------------------------
+
  *  nfcore/viralrecon custom profile Nextflow config file
+
  * -------------------------------------------------
+
  * Defines viral reference genomes for all environments.
+
  */
 
 params {
+
   // Genome reference file paths
+
   genomes {
+
+    // This reference is the MonkeyPox B.1 reference currently used by https://github.com/nextstrain/monkeypox/
+
+    // primer schemes are being developed but not finalised yet so this only supports metagenomes
+
+    'NC_063383.1' {
+
+        fasta             =  '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/2022-06-29T12h.fasta.gz'
+        
+        nextclade_dataset     		 = '/home/workaccount/Work/postdoc/test-datasets/genome/NC_063383.1/nextclade_hMPXV_B1_2022-06-29T12h.tar.gz'
+
+        nextclade_dataset_reference  = 'pseudo_ON563414'
+
+        nextclade_dataset_tag		 = '2022-06-29T12:00:00Z'
+
+    }
+
     'NC_045512.2' {
+
       // This version of the reference has been kept here for backwards compatibility.
+
       // Please use 'MN908947.3' if possible because all primer sets are available / have been pre-prepared relative to that assembly
+
       fasta            = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
+
       gff              = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.gff.gz'
+
       nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
+
       nextclade_dataset_name      = 'sars-cov-2'
+
       nextclade_dataset_reference = 'MN908947'
+
       nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
+
     }
+
     'MN908947.3' {
+
       fasta            = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.fna.gz'
+
       gff              = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
       nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
+
       nextclade_dataset_name      = 'sars-cov-2'
+
       nextclade_dataset_reference = 'MN908947'
+
       nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
+
       primer_sets {
+
         artic {
+
           '1' {
+
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V1/nCoV-2019.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V1/nCoV-2019.primer.bed'
+
             scheme     = 'nCoV-2019'
+
           }
+
           '2' {
+
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V2/nCoV-2019.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V2/nCoV-2019.primer.bed'
+
             scheme     = 'nCoV-2019'
+
           }
+
           '3' {
+
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V3/nCoV-2019.primer.bed'
+
             scheme     = 'nCoV-2019'
+
           }
+
           '4' {
+
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4/SARS-CoV-2.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4/SARS-CoV-2.scheme.bed'
+
             scheme     = 'SARS-CoV-2'
+
           }
+
           '4.1' {
+
             fasta      = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/artic-network/artic-ncov2019/raw/master/primer_schemes/nCoV-2019/V4.1/SARS-CoV-2.scheme.bed'
+
             scheme     = 'SARS-CoV-2'
+
           }          
+
           '1200' {
+
             fasta      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/primer_schemes/artic/nCoV-2019/V1200/nCoV-2019.reference.fasta'
+
             gff        = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
+
             primer_bed = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/primer_schemes/artic/nCoV-2019/V1200/nCoV-2019.bed'
+
             scheme     = 'nCoV-2019'
+
           }
+
         }
+
       }
+
     }
+
   }
+
 }
+

--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -1,4 +1,3 @@
-
 /*
  * -------------------------------------------------
  *  nfcore/viralrecon custom profile Nextflow config file


### PR DESCRIPTION
The `viralrecon` pipeline also works for assembling hMPX genomes. This PR adds paths to `genomes.config` for the `NC_063383.1` genome, pointing to data from nextclade that I have made a PR to add  into `nf-core/test-datasets` (cf nf-core/test-datasets#594). 

I have tested this config file successfully locally, and changed the paths such that this works when the aforementioned PR is merged.

Let me know if there are any changes I should make, thank you!

- [x] Your PR targets the master branch

Thanks to @fmaguire for his assistance on this.
