### PR TITLE
Fix cheaha config due to use of incorrect variable

### DIFF
--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -9,7 +9,7 @@ params {
 }
 
 env {
-    TMPDIR="$USER"
+    TMPDIR="$scratch_dir"
     SINGULARITY_TMPDIR="$scratch_dir"
 }
 


### PR DESCRIPTION
---
Name: Fix cheaha config due to use of incorrect variable
---
**Description**: Updating the cheaha config to correct which variable is being assigned to TMPDIR. This should wrap up the changes and fixes starting in #404 and continued in #410.
