### PR TITLE
Improve reliability of file transfers with retries and reduced concurrency

### DIFF
--- a/conf/sage.config
+++ b/conf/sage.config
@@ -29,9 +29,12 @@ aws {
   region = "us-east-1"
   client {
     uploadChunkSize = 209715200
+    uploadMaxThreads = 4
   }
   batch {
     maxParallelTransfers = 1
+    maxTransferAttempts = 5
+    delayBetweenAttempts = '120 sec'
   }
 }
 executor {

--- a/docs/sage.md
+++ b/docs/sage.md
@@ -8,6 +8,7 @@ This global configuration includes the following tweaks:
 - Enable retries by default when exit codes relate to insufficient memory
 - Allow pending jobs to finish if the number of retries are exhausted
 - Increase the amount of time allowed for file transfers
+- Improve reliability of file transfers with retries and reduced concurrency
 - Increase the default chunk size for multipart uploads to S3
 - Slow down job submission rate to avoid overwhelming any APIs
 - Define the `check_max()` function, which is missing in Sarek v2


### PR DESCRIPTION
This PR makes minor tweaks to how Nextflow downloads files since we've been dealing with the two following errors. Enabling file transfer retries and adding a longer delay between attempts seems to have improved the overall reliability of downloads. This means we don't have to rely on job retries, which have the side-effect of increasing the memory allocation. This is undesirable when the reason that the job failed was due to file staging. 

```
download failed: s3://... [Errno 12] Cannot allocate memory

download failed: s3://... An error occurred while reading from response stream: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```