### PR TITLE
feat(demultiplex): Add optimized transfers for bases2fastq

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Currently documentation is available for the following pipelines within specific
   - [SBC_SHARC](docs/pipeline/atacseq/sbc_sharc.md)
 - chipseq
   - [SBC_SHARC](docs/pipeline/chipseq/sbc_sharc.md)
+- demultiplex
+  - [AWS_TOWER](docs/pipeline/demultiplex/aws_tower.md)
 - eager
   - [EVA](docs/pipeline/eager/eva.md)
 - mag

--- a/conf/pipeline/demultiplex/aws_tower.config
+++ b/conf/pipeline/demultiplex/aws_tower.config
@@ -1,0 +1,29 @@
+// Profile config names for nf-core/configs
+
+params {
+  // Specific nf-core/configs params
+  config_profile_contact = 'Edmund Miller(@emiller88)'
+  config_profile_description = 'nf-core/demultiplex AWS Tower profile provided by nf-core/configs'
+}
+
+aws {
+   batch {
+      maxParallelTransfers = 24
+      maxTransferAttempts = 3
+   }
+   client {
+      maxConnections = 24
+      uploadMaxThreads = 24
+      maxErrorRetry = 3
+      socketTimeout = 3600000
+      uploadRetrySleep = 1000
+      uploadChunkSize = 32.MB
+   }
+}
+
+process {
+    withName: BASES2FASTQ {
+        cpus = 16
+        memory = 48.GB
+    }
+}

--- a/docs/pipeline/demultiplex/aws_tower.md
+++ b/docs/pipeline/demultiplex/aws_tower.md
@@ -1,0 +1,19 @@
+# nf-core/configs: AWS Tower Demultiplex specific configuration
+
+Extra specific configuration for demultiplex pipeline
+
+## Usage
+
+To use, run the pipeline with `-profile aws_tower`.
+
+This will download and launch the demultiplex specific [`aws_tower.config`](../../../conf/pipeline/demultiplex/aws_tower.config) which has been pre-configured with a setup suitable for AWS batch through tower.
+
+Example: `nextflow run nf-core/demultiplex -profile aws_tower`
+
+## eager specific configurations for eva
+
+Specific configurations for AWS has been made for demultiplex.
+
+### General profiles
+
+- The general AWS Tower profile runs with default nf-core/demultiplex parameters, but with modifications to account file transfer speed and optimized bases2fastq resources.

--- a/pipeline/demultiplex.config
+++ b/pipeline/demultiplex.config
@@ -1,0 +1,13 @@
+/*
+ * -------------------------------------------------
+ *  nfcore/demultiplex custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/demultiplex folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+  aws_tower { includeConfig "${params.custom_config_base}/conf/pipeline/demultiplex/aws_tower.config" }
+}


### PR DESCRIPTION
---
name: demultiplex AWS Tower
about: New settings for demultiplex on AWS Batch through Tower
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

@blajoie

We've seen significant speed ups from setting the AWS config. Definitely don't want to break general usage of aws_tower so I think this is a good compromise to still allow it to be "automatically" set and we can work with anyone who doesn't like that as the default.
