### PR TITLE
vsc_ugent: limit queuesize

### DIFF
--- a/conf/vsc_ugent.config
+++ b/conf/vsc_ugent.config
@@ -7,9 +7,11 @@ workDir = "$scratch_dir/work"
 // Perform work directory cleanup when the run has succesfully completed
 // cleanup = true
 
-// Reduce the job submit rate to about 5 per second, this way the server won't be bombarded with jobs
+// Reduce the job submit rate to about 3 per second, this way the server won't be bombarded with jobs
+// Limit queueSize to keep job rate under control and avoid timeouts
 executor {
     submitRateLimit = '3 sec'
+    queueSize = 50
 }
 
 // Specify that singularity should be used and where the cache dir will be for the images


### PR DESCRIPTION
Update vsc_ugent config to limit queueSize, so we stop getting slurm controller timeouts