### PR TITLE
Remove singularity cache dir

### DIFF
--- a/conf/tigem.config
+++ b/conf/tigem.config
@@ -10,5 +10,4 @@ google.zone = 'europe-west1'
 singularity {
     enabled = true
     autoMounts = true
-    cacheDir = 'work/singularity'
 }

--- a/docs/tigem.md
+++ b/docs/tigem.md
@@ -2,6 +2,19 @@
 
 To use, run the pipeline with `-profile tigem`. This will download and launch the tigem.config which has been pre-configured with a setup suitable for the TIGEM personal biocluster.
 
+## Personal bash configuration
+
+Before running the pipeline, make sure to set these environment variables in your bash profile. You can either copy and past these line in your command line or set them as global environment variables adding them in your .bashrc personal file.
+
+```bash
+# set your personal path
+# >>> nf-core variables >>>
+export NXF_SINGULARITY_CACHEDIR="/personal/path/.singularity/"
+export SINGULARITY_CACHEDIR="/personal/path/.singularity"
+export SINGULARITY_TMPDIR="/personal/path/.singularity"
+# <<< nf-core variables <<<
+```
+
 ---
 
 This configuration profile can be used on TIGEM clusters, with the pre-installed SLURM job scheduling system. An additional parameter is `google.zone` to allow downloading data from GCP for a specific time zone. It should not interfere with any local or other AWS configuration.


### PR DESCRIPTION
---
name: Updte TIGEM setting
about: Use of singularity
---

For the correct use of singularity for nf-core pipeline i've remove the singularity cache dir parameters from config and expressed them in the .bashrc hidden file.

I'll set this further information/steps in the doc file.
