### PR TITLE
Update imperial.config

### DIFF
--- a/conf/imperial.config
+++ b/conf/imperial.config
@@ -16,34 +16,58 @@ profiles {
     imperial {
         process {
             executor = 'pbspro'
+            
+            // Update amount of max retries and set "retry" as the error strategy for all error codes
+            errorStrategy = 'retry'
+            maxRetries = 10
+            maxErrors = '-1'
+
+            // General resource requirements
+            queue  = 'v1_short8'
+            cpus   = { 1    * task.attempt }
+            memory = { 6.GB * task.attempt }
+            time   = { 4.h  * task.attempt }
 
             // Process-specific resource requirements
+            withLabel:process_single {
+                // TARGET QUEUE: short
+                queue  = 'v1_short8'
+                cpus   = 1
+                memory = { 6.GB * task.attempt }
+                time   = { 4.h  * task.attempt }
+            }
+
             withLabel:process_low {
                 // TARGET QUEUE: throughput
+                queue  = 'v1_throughput72'
                 cpus   = { 2     * task.attempt }
                 memory = { 12.GB * task.attempt }
-                time   = { 4.h   * task.attempt }
+                time   = { 9.h   * task.attempt }
             }
             withLabel:process_medium {
                 // TARGET QUEUE: throughput
+                queue  = 'v1_throughput72'
                 cpus   = 8
                 memory = { 32.GB * task.attempt }
-                time   = { 8.h   * task.attempt }
+                time   = { 9.h   * task.attempt }
             }
             withLabel:process_high {
                 // TARGET QUEUE: general
+                queue  = 'v1_general72'
                 cpus   = 32
                 memory = { 62.GB * task.attempt }
-                time   = { 16.h  * task.attempt }
+                time   = { 4.h  * task.attempt }
             }
             withLabel:process_long {
-                // TARGET QUEUE: long
-                cpus   = 8
+                // TARGET QUEUE: medium
+                queue  = 'v1_medium72'
+                cpus   = 9
                 memory = 96.GB
-                time   = { 72.h  * task.attempt }
+                time   = { 12.h  * task.attempt }
             }
             withLabel:process_high_memory {
                 // TARGET QUEUE: large memory
+                queue  = 'v1_largemem72'
                 cpus   = { 10     * task.attempt }
                 memory = { 120.GB * task.attempt }
                 time   = { 12.h   * task.attempt }


### PR DESCRIPTION
Nextflow doesn't know how to correctly parse the output of the qstat function our HPC uses. The solution for this is to specify the queue for each process explicitly. This prevented nextflow from dynamically updating the resource requirements for a process in case the process failed. This solution was suggested by Pontus Freyhult on the nf-core/configs slack channel. I also modified the resources to match the job sizing guidance on https://wiki.imperial.ac.uk/pages/viewpage.action?spaceKey=HPC&title=New+Job+sizing+guidance. 

---
name: New Config
about: A new cluster config
---
