### PR TITLE
Update charliecloud module version

### DIFF
--- a/conf/biohpc_gen.config
+++ b/conf/biohpc_gen.config
@@ -12,7 +12,7 @@ env {
 process {
   executor = 'slurm'
   queue    = { task.memory <= 1536.GB ? (task.time > 2.d || task.memory > 384.GB ? 'biohpc_gen_production' : 'biohpc_gen_normal') : 'biohpc_gen_highmem' }
-  module   = 'charliecloud/0.25'
+  module   = 'charliecloud/0.30'
 }
 
 charliecloud {


### PR DESCRIPTION
Use charliecloud module v 0.30 instead of 0.25 which resolves problems stemming from loading an old version, see here https://github.com/nextflow-io/nextflow/pull/3116

