### PR TITLE
Update PSMN cluster config

### DIFF
--- a/conf/psmn.config
+++ b/conf/psmn.config
@@ -8,7 +8,7 @@ params {
 charliecloud {
   enabled = true
   cacheDir = "/Xnfs/abc/charliecloud"
-  runOptions = "--bind /scratch:/scratch --bind /Xnfs:/Xnfs"
+  runOptions = "--bind /scratch:/scratch --bind /Xnfs:/Xnfs --bind /home:/home"
   readOnlyInputs = true
 }
 

--- a/conf/psmn.config
+++ b/conf/psmn.config
@@ -9,6 +9,7 @@ charliecloud {
   enabled = true
   cacheDir = "/Xnfs/abc/charliecloud"
   runOptions = "--bind /scratch:/scratch --bind /Xnfs:/Xnfs"
+  readOnlyInputs = true
 }
 
 process {


### PR DESCRIPTION
---
name: PSMN
about: Update PSMN cluster config
---

This configuration update includes 3 things:

- add a `readOnlyInputs = true` to use the charliecloud option introduced in the nextflow commit [8ae001fc66](https://github.com/nextflow-io/nextflow/commit/8ae001fc66565f3471d48a98c9d49c5001853452)
- add a `--bind /Xnfs:/Xnfs` to better enforce the PSMN policy for shared storage
- add a `--bind /home:/home` to resolve problems with containers using python numba
