### PR TITLE
EVA: Remove queueSize limit to allow cluster to decide

### DIFF
--- a/conf/eva.config
+++ b/conf/eva.config
@@ -20,10 +20,6 @@ process {
     clusterOptions = { "-S /bin/bash -V -j y -o output.sge -l h_vmem=${task.memory.toGiga()}G" }
 }
 
-executor {
-    queueSize = 8
-}
-
 profiles {
     archgen {
       params {


### PR DESCRIPTION
As told to me by the sys admin... lets see if this 'works'...