### PR TITLE
Add funcscan-specific institutional profile for HKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Currently documentation is available for the following pipelines within specific
   - [AWS_TOWER](docs/pipeline/demultiplex/aws_tower.md)
 - eager
   - [EVA](docs/pipeline/eager/eva.md)
+- funcscan
+  - [HKI](docs/pipeline/funcscan/hki.md)
 - mag
   - [Engaging](docs/pipeline/mag/engaging.md)
   - [EVA](docs/pipeline/mag/eva.md)

--- a/conf/pipeline/funcscan/hki.config
+++ b/conf/pipeline/funcscan/hki.config
@@ -1,0 +1,5 @@
+params {
+  config_profile_description = 'nf-core/funcscan profile for HKI clusters provided by nf-core/configs.'
+  config_profile_contact = 'James Fellows Yates (@jfy133)'
+  config_profile_url = 'https://leibniz-hki.de'
+}

--- a/docs/pipeline/funcscan/hki.md
+++ b/docs/pipeline/funcscan/hki.md
@@ -1,0 +1,15 @@
+# nf-core/configs: hki funcscan specific configuration
+
+Extra specific configuration for the funcscan pipeline
+
+## Usage
+
+To use, run the pipeline with `-profile hki`.
+
+This will download and launch the HKI specific [`hki.config`](../../../conf/pipeline/funcscan/hki.config) which has been pre-configured with a setup suitable for the MPI-EVA cluster.
+
+Example: `nextflow run nf-core/funcscan -profile hki`
+
+## funcscan specific configurations for hki
+
+No specific settings are applied for this profile currently - it is a 'dummy' profile to allow activation of pipeline-specific institutional profiles in the funcscan pipeline.

--- a/pipeline/funcscan.config
+++ b/pipeline/funcscan.config
@@ -1,0 +1,15 @@
+
+
+/*
+ * -------------------------------------------------
+ *  nfcore/funcscan custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/eager folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+  hki { includeConfig "${params.custom_config_base}/conf/pipeline/funcscan/hki.config" }
+}


### PR DESCRIPTION
Doesn't do anything currently as doesn't need any special settings - however adding it to allow activation such pipeline-specific profiles in the pipeline :)