### PR TITLE
adding vsc_kul_uhasselt configs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,7 @@ jobs:
           - "utd_sysbio"
           - "uzh"
           - "vai"
+          - "vsc_kul_uhasselt"
           - "vsc_ugent"
           - "wehi"
           - "xanadu"

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Currently documentation is available for the following systems:
 - [UTD_SYSBIO](docs/utd_sysbio.md)
 - [UZH](docs/uzh.md)
 - [VAI](docs/vai.md)
+- [VSC_KUL_UHASSELT](docs/vsc_kul_uhasselt.md)
 - [VSC_UGENT](docs/vsc_ugent.md)
 - [WEHI](docs/wehi.md)
 - [XANADU](docs/xanadu.md)

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -52,7 +52,24 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = 'genius'
+            queue = 'batch'
+            scratch = "$scratch_dir"
+        }
+    }
+
+    genius_long {
+        params {
+            config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC using long nodes (for jobs up to 168h).'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 192.GB
+            max_cpus = 36
+            max_time = 168.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'batch_long'
             scratch = "$scratch_dir"
         }
     }
@@ -69,7 +86,24 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = 'wice'
+            queue = 'batch'
+            scratch = "$scratch_dir"
+        }
+    }
+
+    wice_long {
+        params {
+            config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC using long nodes (for jobs up to 168h).'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 256.GB
+            max_cpus = 72
+            max_time = 168.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'batch_long '
             scratch = "$scratch_dir"
         }
     }
@@ -87,6 +121,23 @@ profiles {
         process {
             executor = 'slurm'
             queue = 'superdome'
+            scratch = "$scratch_dir"
+        }
+    }
+
+    superdome_long {
+        params {
+            config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 750.GB
+            max_cpus = 14
+            max_time = 72.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'superdome_long'
             scratch = "$scratch_dir"
         }
     }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -71,7 +71,7 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' : 'batch_long' }
-            clusterOptions = { "--account=${params.project}" }
+            clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"
         }
     }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -46,32 +46,20 @@ profiles {
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
             max_memory = 192.GB
-            max_cpus = 36
-            max_time = 72.h
-        }
-
-        process {
-            executor = 'slurm'
-            queue = 'batch'
-            clusterOptions = {"--ntasks-per-node ${task.cpus}"}
-            scratch = "$scratch_dir"
-        }
-    }
-
-    genius_long {
-        params {
-            config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC using long nodes (for jobs up to 168h).'
-            config_profile_contact = 'joon.klaps@kuleuven.be'
-            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 192.GB
-            max_cpus = 36
             max_time = 168.h
+            max_cpus = 36
         }
 
         process {
             executor = 'slurm'
-            queue = 'batch_long'
+            queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
+            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
             scratch = "$scratch_dir"
+        }
+
+        executor {
+            queueSize = 10
+            submitRateLimit = '8 sec'
         }
     }
 
@@ -82,30 +70,19 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
             max_memory = 256.GB
             max_cpus = 72
-            max_time = 72.h
-        }
-
-        process {
-            executor = 'slurm'
-            queue = 'batch'
-            scratch = "$scratch_dir"
-        }
-    }
-
-    wice_long {
-        params {
-            config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC using long nodes (for jobs up to 168h).'
-            config_profile_contact = 'joon.klaps@kuleuven.be'
-            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 256.GB
-            max_cpus = 72
             max_time = 168.h
         }
 
-        process {
+         process {
             executor = 'slurm'
-            queue = 'batch_long '
+            queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
+            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
             scratch = "$scratch_dir"
+        }
+
+        executor {
+            queueSize = 10
+            submitRateLimit = '8 sec'
         }
     }
 
@@ -116,30 +93,19 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
             max_memory = 750.GB
             max_cpus = 14
-            max_time = 72.h
+            max_time = 168.h
         }
 
         process {
             executor = 'slurm'
-            queue = 'superdome'
+            queue = { task.time <= 72.h ? 'superdome' : task.time <= 168.h ? 'superdome_long' }
+            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
             scratch = "$scratch_dir"
         }
-    }
 
-    superdome_long {
-        params {
-            config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
-            config_profile_contact = 'joon.klaps@kuleuven.be'
-            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 750.GB
-            max_cpus = 14
-            max_time = 72.h
-        }
-
-        process {
-            executor = 'slurm'
-            queue = 'superdome_long'
-            scratch = "$scratch_dir"
+        executor {
+            queueSize = 10
+            submitRateLimit = '8 sec'
         }
     }
 }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -11,7 +11,7 @@ cleanup = true
 // Limit queueSize to keep job rate under control and avoid timeouts
 executor {
     submitRateLimit = '30/1min'
-    queueSize = 100
+    queueSize = 10
 }
 
 // Add backoff strategy to catch cluster timeouts and proper symlinks of files in scratch to the work directory
@@ -53,13 +53,8 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
-            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
+            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
-        }
-
-        executor {
-            queueSize = 10
-            submitRateLimit = '8 sec'
         }
     }
 
@@ -76,14 +71,9 @@ profiles {
          process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
-            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
+            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
-        }
-
-        executor {
-            queueSize = 10
-            submitRateLimit = '8 sec'
-        }
+        }        
     }
 
     superdome {
@@ -99,13 +89,8 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'superdome' : task.time <= 168.h ? 'superdome_long' }
-            clusterOptions = {"--ntasks-per-node ${task.cpus} --account=${params.project}"}
+            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
-        }
-
-        executor {
-            queueSize = 10
-            submitRateLimit = '8 sec'
-        }
+        }       
     }
 }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -68,12 +68,12 @@ profiles {
             max_time = 168.h
         }
 
-         process {
+        process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
             clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
-        }        
+        }
     }
 
     superdome {
@@ -91,6 +91,6 @@ profiles {
             queue = { task.time <= 72.h ? 'superdome' : task.time <= 168.h ? 'superdome_long' }
             clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
-        }       
+        }
     }
 }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -53,6 +53,7 @@ profiles {
         process {
             executor = 'slurm'
             queue = 'batch'
+            clusterOptions = {"--ntasks-per-node ${task.cpus}"}
             scratch = "$scratch_dir"
         }
     }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -52,7 +52,7 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
+            queue = { task.time <= 72.h ? 'batch' :  'batch_long' }
             clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
         }
@@ -70,7 +70,7 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = { task.time <= 72.h ? 'batch' : task.time <= 168.h ? 'batch_long' }
+            queue = { task.time <= 72.h ? 'batch' : 'batch_long' }
             clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
         }
@@ -88,7 +88,7 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = { task.time <= 72.h ? 'superdome' : task.time <= 168.h ? 'superdome_long' }
+            queue = { task.time <= 72.h ? 'superdome' : 'superdome_long' }
             clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
             scratch = "$scratch_dir"
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -53,7 +53,7 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' :  'batch_long' }
-            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
+            clusterOptions = { "--account=${params.project}" }
             scratch = "$scratch_dir"
         }
     }
@@ -71,7 +71,7 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'batch' : 'batch_long' }
-            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
+            clusterOptions = { "--account=${params.project}" }
             scratch = "$scratch_dir"
         }
     }
@@ -89,7 +89,7 @@ profiles {
         process {
             executor = 'slurm'
             queue = { task.time <= 72.h ? 'superdome' : 'superdome_long' }
-            clusterOptions = { "--ntasks-per-node=${task.cpus} --account=${params.project}" }
+            clusterOptions = { "--account=${params.project}" }
             scratch = "$scratch_dir"
         }
     }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -73,4 +73,21 @@ profiles {
             scratch = "$scratch_dir"
         }
     }
+
+    superdome {
+        params {
+            config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 750.GB
+            max_cpus = 14
+            max_time = 72.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'superdome'
+            scratch = "$scratch_dir"
+        }
+    }
 }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -1,0 +1,76 @@
+// Define the Scratch directory
+def scratch_dir = System.getenv("VSC_SCRATCH") ?: "scratch/"
+
+// Specify the work directory
+workDir = "$scratch_dir/work"
+
+// Perform work directory cleanup when the run has succesfully completed
+cleanup = true
+
+// Reduce the job submit rate to about 30 per minute, this way the server won't be bombarded with jobs
+// Limit queueSize to keep job rate under control and avoid timeouts
+executor {
+    submitRateLimit = '30/1min'
+    queueSize = 100
+}
+
+// Add backoff strategy to catch cluster timeouts and proper symlinks of files in scratch to the work directory
+process {
+    stageInMode = "symlink"
+    stageOutMode = "rsync"
+    errorStrategy = { sleep(Math.pow(2, task.attempt) * 200 as long); return 'retry' }
+    maxRetries    = 5
+}
+
+// Specify that singularity should be used and where the cache dir will be for the images
+singularity {
+    enabled = true
+    autoMounts = true
+    cacheDir = "$scratch_dir/.singularity"
+}
+
+env {
+    SINGULARITY_CACHEDIR="$scratch_dir/.singularity"
+}
+
+// AWS maximum retries for errors (This way the pipeline doesn't fail if the download fails one time)
+aws {
+        maxErrorRetry = 3
+}
+
+// Define profiles for each cluster
+profiles {
+    genius {
+        params {
+            config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC.'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 192.GB
+            max_cpus = 36
+            max_time = 72.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'genius'
+            scratch = "$scratch_dir"
+        }
+    }
+
+    wice {
+        params {
+            config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC.'
+            config_profile_contact = 'joon.klaps@kuleuven.be'
+            config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
+            max_memory = 256.GB
+            max_cpus = 72
+            max_time = 72.h
+        }
+
+        process {
+            executor = 'slurm'
+            queue = 'wice'
+            scratch = "$scratch_dir"
+        }
+    }
+}

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -4,29 +4,27 @@
 
 First you should go to the cluster you want to run the pipeline on. You can check what clusters have the most free space using following command `sinfo --cluster wice|genius`.
 
-Before running the pipeline you will need to create a slurm script to submit as a job.
+Before running the pipeline you will need to create a slurm script that acts as a master script to submit as all jobs.
 
 ```bash
 $ more job.pbs
 #!/bin/bash
 #SBATCH --account=...
 #SBATCH --chdir=....
-#SBATCH --nodes="2"
-#SBATCH --ntasks-per-node="36"
+#SBATCH --partition=batch_long
+#SBATCH --nodes="1"
+#SBATCH --ntasks-per-node="1"
 
 module load Nextflow
 
-nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER-option> <Add your other parameters>
+nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER> --project <your-credential-acc> <Add your other parameters>
 ```
 
 Here the cluster options are:
 
-- genius (72h)
-- genius_long (168h)
-- wice (72h)
-- wice_long (168h)
-- superdome (72h)
-- superdome_long (168h)
+- genius
+- wice
+- superdome
 
 > **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g. more memory or gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'bigmem*', or 'gpu*').
 

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -4,7 +4,7 @@
 
 First you should go to the cluster you want to run the pipeline on. You can check what clusters have the most free space using following command `sinfo --cluster wice|genius`.
 
-Before running the pipeline you will need to create a slurm script that acts as a master script to submit as all jobs.
+Before running the pipeline you will need to create a slurm script that acts as a master script to submit all jobs.
 
 ```bash
 $ more job.pbs
@@ -19,6 +19,8 @@ module load Nextflow
 
 nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER> --project <your-credential-acc> <Add your other parameters>
 ```
+
+> **NB:** You have to specify your credential account, else the jobs will fail!
 
 Here the cluster options are:
 

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -1,0 +1,35 @@
+# nf-core/configs: KU Leuven/UHasselt Tier-2 High Performance Computing Infrastructure (VSC)
+
+> **NB:** You will need an [account](https://docs.vscentrum.be/en/latest/access/getting_access.html#required-steps-to-get-access) to use the HPC cluster to run the pipeline.
+
+First you should go to the cluster you want to run the pipeline on. You can check what clusters have the most free space using following command `sinfo --cluster wice|genius`.
+
+Before running the pipeline you will need to create a slurm script to submit as a job.
+
+```bash
+$ more job.pbs
+#!/bin/bash
+#SBATCH --account=...
+#SBATCH --chdir=....
+#SBATCH --nodes="2"
+#SBATCH --ntasks-per-node="36"
+
+module load Nextflow
+
+nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER> <Add your other parameters>
+```
+
+Use the `--cluster` option to specify the cluster you intend to use when submitting the job:
+
+```shell
+sbatch --cluster=wice job.slurm 
+```
+
+All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
+The config contains a `cleanup` command that removes the `work/` directory automatically once the pipeline has completed successfully. If the run does not complete successfully then the `work/` dir should be removed manually to save storage space. The default work directory is set to `$VSC_SCRATCH/work` per this configuration
+
+You can also add several TORQUE options to the PBS script. More about this on this [link](http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-linux-gent.pdf#appendix.B).
+
+To submit your job to the cluster by using the following command:
+
+> **NB:** The default directory where the `work/` and `singularity/` (cache directory for images) is located in `$VSC_SCRATCH`.

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -16,20 +16,28 @@ $ more job.pbs
 
 module load Nextflow
 
-nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER> <Add your other parameters>
+nextflow run <pipeline> -profile vsc_kul_uhasselt,<CLUSTER-option> <Add your other parameters>
 ```
+
+Here the cluster options are:
+
+- genius (72h)
+- genius_long (168h)
+- wice (72h)
+- wice_long (168h)
+- superdome (72h)
+- superdome_long (168h)
+
+> **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g. more memory or gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'bigmem*', or 'gpu*').
 
 Use the `--cluster` option to specify the cluster you intend to use when submitting the job:
 
 ```shell
-sbatch --cluster=wice job.slurm 
+sbatch --cluster=wice|genius job.slurm 
 ```
 
 All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
+
 The config contains a `cleanup` command that removes the `work/` directory automatically once the pipeline has completed successfully. If the run does not complete successfully then the `work/` dir should be removed manually to save storage space. The default work directory is set to `$VSC_SCRATCH/work` per this configuration
-
-You can also add several TORQUE options to the PBS script. More about this on this [link](http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-linux-gent.pdf#appendix.B).
-
-To submit your job to the cluster by using the following command:
 
 > **NB:** The default directory where the `work/` and `singularity/` (cache directory for images) is located in `$VSC_SCRATCH`.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -10,88 +10,89 @@
 
 //Please use a new line per include Config section to allow easier linting/parsing. Thank you.
 profiles {
-    abims          { includeConfig "${params.custom_config_base}/conf/abims.config" }
-    adcra          { includeConfig "${params.custom_config_base}/conf/adcra.config" }
-    alice          { includeConfig "${params.custom_config_base}/conf/alice.config" }
-    aws_tower      { includeConfig "${params.custom_config_base}/conf/aws_tower.config" }
-    awsbatch       { includeConfig "${params.custom_config_base}/conf/awsbatch.config" }
-    azurebatch     { includeConfig "${params.custom_config_base}/conf/azurebatch.config" }
-    bi             { includeConfig "${params.custom_config_base}/conf/bi.config" }
-    bigpurple      { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }
-    binac          { includeConfig "${params.custom_config_base}/conf/binac.config" }
-    biohpc_gen     { includeConfig "${params.custom_config_base}/conf/biohpc_gen.config" }
-    cambridge      { includeConfig "${params.custom_config_base}/conf/cambridge.config" }
-    cbe            { includeConfig "${params.custom_config_base}/conf/cbe.config" }
-    ccga_dx        { includeConfig "${params.custom_config_base}/conf/ccga_dx.config" }
-    ccga_med       { includeConfig "${params.custom_config_base}/conf/ccga_med.config" }
-    cedars         { includeConfig "${params.custom_config_base}/conf/cedars.config" }
-    ceres          { includeConfig "${params.custom_config_base}/conf/ceres.config" }
-    cfc            { includeConfig "${params.custom_config_base}/conf/cfc.config" }
-    cfc_dev        { includeConfig "${params.custom_config_base}/conf/cfc_dev.config" }
-    cheaha         { includeConfig "${params.custom_config_base}/conf/cheaha.config" }
-    computerome    { includeConfig "${params.custom_config_base}/conf/computerome.config" }
-    crg            { includeConfig "${params.custom_config_base}/conf/crg.config" }
-    crick          { includeConfig "${params.custom_config_base}/conf/crick.config" }
-    crukmi         { includeConfig "${params.custom_config_base}/conf/crukmi.config" }
-    czbiohub_aws   { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
-    denbi_qbic     { includeConfig "${params.custom_config_base}/conf/denbi_qbic.config" }
-    dkfz           { includeConfig "${params.custom_config_base}/conf/dkfz.config" }
-    ebc            { includeConfig "${params.custom_config_base}/conf/ebc.config" }
-    eddie          { includeConfig "${params.custom_config_base}/conf/eddie.config" }
-    engaging       { includeConfig "${params.custom_config_base}/conf/engaging.config" }
-    eva            { includeConfig "${params.custom_config_base}/conf/eva.config" }
-    fgcz           { includeConfig "${params.custom_config_base}/conf/fgcz.config" }
-    genotoul       { includeConfig "${params.custom_config_base}/conf/genotoul.config" }
-    genouest       { includeConfig "${params.custom_config_base}/conf/genouest.config" }
-    gis            { includeConfig "${params.custom_config_base}/conf/gis.config" }
-    google         { includeConfig "${params.custom_config_base}/conf/google.config" }
-    googlebatch    { includeConfig "${params.custom_config_base}/conf/googlebatch.config" }
-    googlels       { includeConfig "${params.custom_config_base}/conf/googlels.config" }
-    hasta          { includeConfig "${params.custom_config_base}/conf/hasta.config" }
-    hki            { includeConfig "${params.custom_config_base}/conf/hki.config"}
-    icr_davros     { includeConfig "${params.custom_config_base}/conf/icr_davros.config" }
-    ifb_core       { includeConfig "${params.custom_config_base}/conf/ifb_core.config" }
-    imperial       { includeConfig "${params.custom_config_base}/conf/imperial.config" }
-    ipop_up        { includeConfig "${params.custom_config_base}/conf/ipop_up.config" }
-    janelia        { includeConfig "${params.custom_config_base}/conf/janelia.config" }
-    jax            { includeConfig "${params.custom_config_base}/conf/jax.config" }
-    ku_sund_dangpu { includeConfig "${params.custom_config_base}/conf/ku_sund_dangpu.config"}
-    leicester      { includeConfig "${params.custom_config_base}/conf/leicester.config" }
-    lugh           { includeConfig "${params.custom_config_base}/conf/lugh.config" }
-    maestro        { includeConfig "${params.custom_config_base}/conf/maestro.config" }
-    mana           { includeConfig "${params.custom_config_base}/conf/mana.config" }
-    marvin         { includeConfig "${params.custom_config_base}/conf/marvin.config" }
-    medair         { includeConfig "${params.custom_config_base}/conf/medair.config" }
-    mjolnir_globe  { includeConfig "${params.custom_config_base}/conf/mjolnir_globe.config" }
-    mpcdf          { includeConfig "${params.custom_config_base}/conf/mpcdf.config" }
-    munin          { includeConfig "${params.custom_config_base}/conf/munin.config" }
-    nihbiowulf     { includeConfig "${params.custom_config_base}/conf/nihbiowulf.config" }
-    nu_genomics    { includeConfig "${params.custom_config_base}/conf/nu_genomics.config" }
-    oist           { includeConfig "${params.custom_config_base}/conf/oist.config" }
-    pasteur        { includeConfig "${params.custom_config_base}/conf/pasteur.config" }
-    phoenix        { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
-    prince         { includeConfig "${params.custom_config_base}/conf/prince.config" }
-    psmn           { includeConfig "${params.custom_config_base}/conf/psmn.config" }
-    rosalind       { includeConfig "${params.custom_config_base}/conf/rosalind.config" }
-    rosalind_uge   { includeConfig "${params.custom_config_base}/conf/rosalind_uge.config" }
-    sage           { includeConfig "${params.custom_config_base}/conf/sage.config" }
-    sahmri         { includeConfig "${params.custom_config_base}/conf/sahmri.config" }
-    sanger         { includeConfig "${params.custom_config_base}/conf/sanger.config"}
-    sbc_sharc      { includeConfig "${params.custom_config_base}/conf/sbc_sharc.config"}
-    scw            { includeConfig "${params.custom_config_base}/conf/scw.config"}
-    seawulf        { includeConfig "${params.custom_config_base}/conf/seawulf.config"}
-    seg_globe      { includeConfig "${params.custom_config_base}/conf/seg_globe.config"}
-    tigem          { includeConfig "${params.custom_config_base}/conf/tigem.config"}
-    ucl_myriad     { includeConfig "${params.custom_config_base}/conf/ucl_myriad.config"}
-    uct_hpc        { includeConfig "${params.custom_config_base}/conf/uct_hpc.config" }
-    uge            { includeConfig "${params.custom_config_base}/conf/uge.config" }
-    unibe_ibu      { includeConfig "${params.custom_config_base}/conf/unibe_ibu.config" }
-    uppmax         { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
-    utd_ganymede   { includeConfig "${params.custom_config_base}/conf/utd_ganymede.config" }
-    utd_sysbio     { includeConfig "${params.custom_config_base}/conf/utd_sysbio.config" }
-    uzh            { includeConfig "${params.custom_config_base}/conf/uzh.config" }
-    vai            { includeConfig "${params.custom_config_base}/conf/vai.config" }
-    vsc_ugent      { includeConfig "${params.custom_config_base}/conf/vsc_ugent.config" }
-    wehi           { includeConfig "${params.custom_config_base}/conf/wehi.config" }
-    xanadu         { includeConfig "${params.custom_config_base}/conf/xanadu.config" }
+    abims            { includeConfig "${params.custom_config_base}/conf/abims.config" }
+    adcra            { includeConfig "${params.custom_config_base}/conf/adcra.config" }
+    alice            { includeConfig "${params.custom_config_base}/conf/alice.config" }
+    aws_tower        { includeConfig "${params.custom_config_base}/conf/aws_tower.config" }
+    awsbatch         { includeConfig "${params.custom_config_base}/conf/awsbatch.config" }
+    azurebatch       { includeConfig "${params.custom_config_base}/conf/azurebatch.config" }
+    bi               { includeConfig "${params.custom_config_base}/conf/bi.config" }
+    bigpurple        { includeConfig "${params.custom_config_base}/conf/bigpurple.config" }
+    binac            { includeConfig "${params.custom_config_base}/conf/binac.config" }
+    biohpc_gen       { includeConfig "${params.custom_config_base}/conf/biohpc_gen.config" }
+    cambridge        { includeConfig "${params.custom_config_base}/conf/cambridge.config" }
+    cbe              { includeConfig "${params.custom_config_base}/conf/cbe.config" }
+    ccga_dx          { includeConfig "${params.custom_config_base}/conf/ccga_dx.config" }
+    ccga_med         { includeConfig "${params.custom_config_base}/conf/ccga_med.config" }
+    cedars           { includeConfig "${params.custom_config_base}/conf/cedars.config" }
+    ceres            { includeConfig "${params.custom_config_base}/conf/ceres.config" }
+    cfc              { includeConfig "${params.custom_config_base}/conf/cfc.config" }
+    cfc_dev          { includeConfig "${params.custom_config_base}/conf/cfc_dev.config" }
+    cheaha           { includeConfig "${params.custom_config_base}/conf/cheaha.config" }
+    computerome      { includeConfig "${params.custom_config_base}/conf/computerome.config" }
+    crg              { includeConfig "${params.custom_config_base}/conf/crg.config" }
+    crick            { includeConfig "${params.custom_config_base}/conf/crick.config" }
+    crukmi           { includeConfig "${params.custom_config_base}/conf/crukmi.config" }
+    czbiohub_aws     { includeConfig "${params.custom_config_base}/conf/czbiohub_aws.config" }
+    denbi_qbic       { includeConfig "${params.custom_config_base}/conf/denbi_qbic.config" }
+    dkfz             { includeConfig "${params.custom_config_base}/conf/dkfz.config" }
+    ebc              { includeConfig "${params.custom_config_base}/conf/ebc.config" }
+    eddie            { includeConfig "${params.custom_config_base}/conf/eddie.config" }
+    engaging         { includeConfig "${params.custom_config_base}/conf/engaging.config" }
+    eva              { includeConfig "${params.custom_config_base}/conf/eva.config" }
+    fgcz             { includeConfig "${params.custom_config_base}/conf/fgcz.config" }
+    genotoul         { includeConfig "${params.custom_config_base}/conf/genotoul.config" }
+    genouest         { includeConfig "${params.custom_config_base}/conf/genouest.config" }
+    gis              { includeConfig "${params.custom_config_base}/conf/gis.config" }
+    google           { includeConfig "${params.custom_config_base}/conf/google.config" }
+    googlebatch      { includeConfig "${params.custom_config_base}/conf/googlebatch.config" }
+    googlels         { includeConfig "${params.custom_config_base}/conf/googlels.config" }
+    hasta            { includeConfig "${params.custom_config_base}/conf/hasta.config" }
+    hki              { includeConfig "${params.custom_config_base}/conf/hki.config"}
+    icr_davros       { includeConfig "${params.custom_config_base}/conf/icr_davros.config" }
+    ifb_core         { includeConfig "${params.custom_config_base}/conf/ifb_core.config" }
+    imperial         { includeConfig "${params.custom_config_base}/conf/imperial.config" }
+    ipop_up          { includeConfig "${params.custom_config_base}/conf/ipop_up.config" }
+    janelia          { includeConfig "${params.custom_config_base}/conf/janelia.config" }
+    jax              { includeConfig "${params.custom_config_base}/conf/jax.config" }
+    ku_sund_dangpu   { includeConfig "${params.custom_config_base}/conf/ku_sund_dangpu.config"}
+    leicester        { includeConfig "${params.custom_config_base}/conf/leicester.config" }
+    lugh             { includeConfig "${params.custom_config_base}/conf/lugh.config" }
+    maestro          { includeConfig "${params.custom_config_base}/conf/maestro.config" }
+    mana             { includeConfig "${params.custom_config_base}/conf/mana.config" }
+    marvin           { includeConfig "${params.custom_config_base}/conf/marvin.config" }
+    medair           { includeConfig "${params.custom_config_base}/conf/medair.config" }
+    mjolnir_globe    { includeConfig "${params.custom_config_base}/conf/mjolnir_globe.config" }
+    mpcdf            { includeConfig "${params.custom_config_base}/conf/mpcdf.config" }
+    munin            { includeConfig "${params.custom_config_base}/conf/munin.config" }
+    nihbiowulf       { includeConfig "${params.custom_config_base}/conf/nihbiowulf.config" }
+    nu_genomics      { includeConfig "${params.custom_config_base}/conf/nu_genomics.config" }
+    oist             { includeConfig "${params.custom_config_base}/conf/oist.config" }
+    pasteur          { includeConfig "${params.custom_config_base}/conf/pasteur.config" }
+    phoenix          { includeConfig "${params.custom_config_base}/conf/phoenix.config" }
+    prince           { includeConfig "${params.custom_config_base}/conf/prince.config" }
+    psmn             { includeConfig "${params.custom_config_base}/conf/psmn.config" }
+    rosalind         { includeConfig "${params.custom_config_base}/conf/rosalind.config" }
+    rosalind_uge     { includeConfig "${params.custom_config_base}/conf/rosalind_uge.config" }
+    sage             { includeConfig "${params.custom_config_base}/conf/sage.config" }
+    sahmri           { includeConfig "${params.custom_config_base}/conf/sahmri.config" }
+    sanger           { includeConfig "${params.custom_config_base}/conf/sanger.config"}
+    sbc_sharc        { includeConfig "${params.custom_config_base}/conf/sbc_sharc.config"}
+    scw              { includeConfig "${params.custom_config_base}/conf/scw.config"}
+    seawulf          { includeConfig "${params.custom_config_base}/conf/seawulf.config"}
+    seg_globe        { includeConfig "${params.custom_config_base}/conf/seg_globe.config"}
+    tigem            { includeConfig "${params.custom_config_base}/conf/tigem.config"}
+    ucl_myriad       { includeConfig "${params.custom_config_base}/conf/ucl_myriad.config"}
+    uct_hpc          { includeConfig "${params.custom_config_base}/conf/uct_hpc.config" }
+    uge              { includeConfig "${params.custom_config_base}/conf/uge.config" }
+    unibe_ibu        { includeConfig "${params.custom_config_base}/conf/unibe_ibu.config" }
+    uppmax           { includeConfig "${params.custom_config_base}/conf/uppmax.config" }
+    utd_ganymede     { includeConfig "${params.custom_config_base}/conf/utd_ganymede.config" }
+    utd_sysbio       { includeConfig "${params.custom_config_base}/conf/utd_sysbio.config" }
+    uzh              { includeConfig "${params.custom_config_base}/conf/uzh.config" }
+    vai              { includeConfig "${params.custom_config_base}/conf/vai.config" }
+    vsc_kul_uhasselt { includeConfig "${params.custom_config_base}/conf/vsc_kul_uhasselt.config" }
+    vsc_ugent        { includeConfig "${params.custom_config_base}/conf/vsc_ugent.config" }
+    wehi             { includeConfig "${params.custom_config_base}/conf/wehi.config" }
+    xanadu           { includeConfig "${params.custom_config_base}/conf/xanadu.config" }
 }


### PR DESCRIPTION
---
name: vsc_kul_uhasselt
about: A new cluster config for the KULeuven and Uhasselt Tier2 clusters Genius and Wice
---
The VSC (Flemish supercomputer) has multiple clusters which are specific to flemish universities.
I propose not to extend the `vsc_ugent.config` file but instead make a new config `vsc_kul_uhasselt.config` as some of the prefixed variables like `$VSC_SCRATCH_VO_USER` are not available on KUL's and UHasselt's HPC. 

Please follow these steps before submitting your PR:

- [X] Your PR targets the `master` branch

Steps for adding a new config profile:

- [X] Add your custom config file to the `conf/` directory
- [X] Add your documentation file to the `docs/` directory
- [X] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [X] Add your custom profile to the `README.md` file in the top-level directory
- [X] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request from @nf-core/configs-team

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
