### PR TITLE
update max_memory and max_time

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -23,7 +23,7 @@ weblog{
 
 params {
   igenomes_base = '/nfsmounts/igenomes'
-  max_memory = 1999.GB
+  max_memory = 1992.GB
   max_cpus = 128
-  max_time = 140.h
+  max_time = 168.h
 }

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -1,7 +1,7 @@
 //Profile config names for nf-core/configs
 params {
   config_profile_description = 'QBiC Core Facility cluster profile provided by nf-core/configs.'
-  config_profile_contact = 'Gisela Gabernet (@ggabernet)'
+  config_profile_contact = 'Friederike Hanssen (@FriederikeHanssen)'
   config_profile_url = 'http://qbic.uni-tuebingen.de/'
 }
 

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -22,7 +22,7 @@ weblog{
 
 params {
   igenomes_base = '/nfsmounts/igenomes'
-  max_memory = 1999.GB
+  max_memory = 1992.GB
   max_cpus = 128
-  max_time = 140.h
+  max_time = 168.h
 }

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -1,7 +1,7 @@
 //Profile config names for nf-core/configs
 params {
   config_profile_description = 'QBiC Core Facility cluster dev profile without container cache provided by nf-core/configs.'
-  config_profile_contact = 'Gisela Gabernet (@ggabernet)'
+  config_profile_contact = 'Friederike Hanssen (@FriederikeHanssen)'
   config_profile_url = 'http://qbic.uni-tuebingen.de/'
 }
 


### PR DESCRIPTION
---
Update cfc configs for cfc2.0 for edge cases
---

We tested and found that the current values are wrong. The actual maximum memory allowed on slurm is 1992 GB, with 1993 GB slurm rejects the job. The job length is allowed until 168h (7days) now.

Open question:
The line `config_profile_contact = 'Gisela Gabernet (@ggabernet)' `seems outdated, who could be named here?

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

<!--
If you require/still waiting for a review, please feel free to request from @nf-core/configs-team

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
