### PR TITLE
Update imperial.config

### DIFF
--- a/conf/imperial.config
+++ b/conf/imperial.config
@@ -24,7 +24,7 @@ profiles {
 
 
             // General resource requirements
-            queue  = { 4 * task.attempt  > 8 ? 'v1_throughput72' : 'v1_short8'}
+            queue  = { 4 * task.attempt  > 8 ? 'v1_throughput72' : 'v1_short8' }
             cpus   = { 1	* task.attempt }
             memory = { 6.GB	* task.attempt }  
             time   = { 4.h	* task.attempt } 
@@ -37,9 +37,10 @@ profiles {
             }
 
             withLabel:process_low {
+            	queue  = 'v1_short8'
                 cpus   = { 2	 * task.attempt }
                 memory = { 12.GB * task.attempt }
-                time   = { 2.h	 * task.attempt }
+                time   = { 2 * task.attempt  > 8 ? 8.h : 2.h * task.attempt }
             }
 
             withLabel:process_medium { 


### PR DESCRIPTION
Changed process_low "time" specification to match the Imperial HPC v1_short8 time limitations and specified v1_short8 explicitly as the queue name in order to avoid the conditional queue switching defined above in the config file. Previous time specification exceeded the max walltime limit if retried more than 4 times.

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request from @nf-core/configs-team

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
