### PR TITLE
Updating VSC_KUL_UHASSELT config for overhead

### DIFF
--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -51,8 +51,8 @@ profiles {
         }
 
         process {
-            def size = task.memory <= 174.GB ? 'batch' : 'bigmem'
-            def time = task.time <= 72.h ? '' : '_long' 
+            size = task.memory <= 174.GB ? 'batch' : 'bigmem' 
+            time = task.time <= 72.h ? '' : '_long' 
             executor = 'slurm'
             queue = { "${size}${time}" }
             clusterOptions = { "--account=${params.project}" }
@@ -72,8 +72,8 @@ profiles {
 
         process {
             executor = 'slurm'
-            def size = task.memory <= 235GB ? 'batch' : 'bigmem' 
-            def partition = task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'   
+            size = task.memory <= 235GB ? 'batch' : 'bigmem' 
+            partition = task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'   
             queue = { "${partition}" }
             clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -45,7 +45,7 @@ profiles {
             config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 750.GB  // 768 - 18 so 18GB for overhead
+            max_memory = 720.GB  // 768 - 48 so 48GB for overhead 
             max_time = 168.h
             max_cpus = 36
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -51,8 +51,8 @@ profiles {
         }
 
         process {
-            size = task.memory <= 174.GB ? 'batch' : 'bigmem' 
-            time = task.time <= 72.h ? '' : '_long' 
+            def size = { task.memory <= 174.GB ? 'batch' : 'bigmem' }
+            def time = { task.time <= 72.h ? '' : '_long' }
             executor = 'slurm'
             queue = { "${size}${time}" }
             clusterOptions = { "--account=${params.project}" }
@@ -72,8 +72,8 @@ profiles {
 
         process {
             executor = 'slurm'
-            size = task.memory <= 235GB ? 'batch' : 'bigmem' 
-            partition = task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'   
+            def size = { task.memory <= 235GB ? 'batch' : 'bigmem' }
+            def partition = { task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem' } 
             queue = { "${partition}" }
             clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -80,7 +80,7 @@ profiles {
             config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 2030.GB // 2048 - 18 so 18GB for overhead
+            max_memory = 2000.GB // 2048 - 48 so 48GB for overhead
             max_cpus = 72
             max_time = 168.h
         }
@@ -115,7 +115,7 @@ profiles {
             config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 750.GB
+            max_memory = 700.GB
             max_cpus = 14
             max_time = 168.h
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -45,7 +45,7 @@ profiles {
             config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 720.GB  // 768 - 48 so 48GB for overhead 
+            max_memory = 720.GB  // 768 - 48 so 48GB for overhead
             max_time = 168.h
             max_cpus = 36
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -54,7 +54,7 @@ profiles {
             executor = 'slurm'
             queue = queue = {
                 switch (task.memory) {
-                case { it >=  174.GB }: // 192 - 18
+                case { it >=  170.GB }: // 192 - 22
                     switch (task.time) {
                     case { it >= 72.h }:
                         return 'dedicated_big_bigmem'
@@ -89,7 +89,7 @@ profiles {
             executor = 'slurm'
             queue = {
                 switch (task.memory) {
-                case { it >=  235.GB }:  // 256 - 18
+                case { it >=  220.GB }:  // 256 - 36
                     switch (task.time) {
                     case { it >= 72.h }:
                         return 'dedicated_big_bigmem'
@@ -115,7 +115,7 @@ profiles {
             config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 700.GB
+            max_memory = 708.GB // 756 - 48
             max_cpus = 14
             max_time = 168.h
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -51,10 +51,25 @@ profiles {
         }
 
         process {
-            def size = { task.memory <= 174.GB ? 'batch' : 'bigmem' }
-            def time = { task.time <= 72.h ? '' : '_long' }
             executor = 'slurm'
-            queue = { "${size}${time}" }
+            queue = queue = {
+                switch (task.memory) {
+                case { it >=  174.GB }: // 192 - 18
+                    switch (task.time) {
+                    case { it >= 72.h }:
+                        return 'dedicated_big_bigmem'
+                    default:
+                        return 'bigmem'
+                    }
+                default:
+                    switch (task.time) {
+                    case { it >= 72.h }:
+                        return 'batch_long'
+                    default:
+                        return 'batch'
+                    }
+                }
+            }
             clusterOptions = { "--account=${params.project}" }
             scratch = "$scratch_dir"
         }
@@ -72,9 +87,24 @@ profiles {
 
         process {
             executor = 'slurm'
-            def size = { task.memory <= 235GB ? 'batch' : 'bigmem' }
-            def partition = { task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem' } 
-            queue = { "${partition}" }
+            queue = {
+                switch (task.memory) {
+                case { it >=  235.GB }:  // 256 - 18
+                    switch (task.time) {
+                    case { it >= 72.h }:
+                        return 'dedicated_big_bigmem'
+                    default:
+                        return 'bigmem'
+                    }
+                default:
+                    switch (task.time) {
+                    case { it >= 72.h }:
+                        return 'batch_long'
+                    default:
+                        return 'batch'
+                    }
+                }
+            }
             clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -45,14 +45,16 @@ profiles {
             config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 192.GB
+            max_memory = 750.GB  // 768 - 18 so 18GB for overhead
             max_time = 168.h
             max_cpus = 36
         }
 
         process {
+            def size = task.memory <= 174.GB ? 'batch' : 'bigmem'
+            def time = task.time <= 72.h ? '' : '_long' 
             executor = 'slurm'
-            queue = { task.time <= 72.h ? 'batch' :  'batch_long' }
+            queue = { "${size}${time}" }
             clusterOptions = { "--account=${params.project}" }
             scratch = "$scratch_dir"
         }
@@ -63,14 +65,15 @@ profiles {
             config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 256.GB
+            max_memory = 2030.GB // 2048 - 18 so 18GB for overhead
             max_cpus = 72
             max_time = 168.h
         }
 
         process {
             executor = 'slurm'
-            queue = { task.time <= 72.h ? 'batch' : 'batch_long' }
+            def partition = task.time <= 72.h ? {task.memory <= 235GB ? 'batch' : 'bigmem'} : {task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'}   
+            queue = { "${partition}" }
             clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -72,7 +72,8 @@ profiles {
 
         process {
             executor = 'slurm'
-            def partition = task.time <= 72.h ? {task.memory <= 235GB ? 'batch' : 'bigmem'} : {task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'}   
+            def size = task.memory <= 235GB ? 'batch' : 'bigmem' 
+            def partition = task.time <= 72.h ? "${size}" : task.memory <= 235GB ? 'batch_long' : 'dedicated_big_bigmem'   
             queue = { "${partition}" }
             clusterOptions = { "--cluster wice --account=${params.project}" }
             scratch = "$scratch_dir"

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -28,7 +28,7 @@ Here the cluster options are:
 - wice
 - superdome
 
-> **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g. more memory or gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'bigmem*', or 'gpu*').
+> **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g.gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'gpu*').
 
 Use the `--cluster` option to specify the cluster you intend to use when submitting the job:
 

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -28,7 +28,7 @@ Here the cluster options are:
 - wice
 - superdome
 
-> **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g.gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'gpu*').
+> **NB:** The vsc_kul_uhasselt profile is based on a selected amount of SLURM partitions. Should you require resources outside of these limits (e.g.gpus) you will need to provide a custom config specifying an appropriate SLURM partition (e.g. 'gpu\*').
 
 Use the `--cluster` option to specify the cluster you intend to use when submitting the job:
 


### PR DESCRIPTION

Current config, was setting the maximum allowed RAM to the total available RAM of a node leaving nothing for overhead. This resulted in an instantly failing of the jobs. This was fixed by leaving a large amount (22GB - 36GB - 48GB) for overhead depending on the total available RAM of the node. Some logic was also added to submit to larger memory nodes on both clusters. 

- [X] Your PR targets the `master` branch
- [X] Test the config 
