### PR TITLE
Support newer nf-validation with new name for ignored params

### DIFF
--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -6,7 +6,7 @@ params {
   project = null
   cache_dir = "/home/projects/$params.project/scratch"
   schema_ignore_params = "project,cache_dir,genomes,modules"
-  validationSchemaIgnoreParams = "project,cache_dir,genomes,genomes,modules,schema_ignore_params"
+  validationSchemaIgnoreParams = "project,cache_dir,genomes,modules,schema_ignore_params"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 

--- a/conf/computerome.config
+++ b/conf/computerome.config
@@ -6,6 +6,7 @@ params {
   project = null
   cache_dir = "/home/projects/$params.project/scratch"
   schema_ignore_params = "project,cache_dir,genomes,modules"
+  validationSchemaIgnoreParams = "project,cache_dir,genomes,genomes,modules,schema_ignore_params"
   
   //Thin nodes with 192GB and Fat nodes with ~1500GB. Torque should be allowed to handle this
   max_memory = 1500.GB 

--- a/conf/hasta.config
+++ b/conf/hasta.config
@@ -6,6 +6,7 @@ params {
   priority = null
   clusterOptions = null
   schema_ignore_params = "priority,clusterOptions"
+  validationSchemaIgnoreParams = "priority,clusterOptions,schema_ignore_params"
 }
 
 singularity {

--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -10,6 +10,7 @@ params {
 
     lsf_opts = ''
     schema_ignore_params = 'genomes,lsf_opts'
+    validationSchemaIgnoreParams = "genomes,lsf_opts,schema_ignore_params"
 }
 
 singularity {

--- a/conf/rosalind.config
+++ b/conf/rosalind.config
@@ -16,6 +16,7 @@ params {
   max_time = 24.h
   partition = 'shared'
   schema_ignore_params = 'partition,genomes,modules'
+  validationSchemaIgnoreParams = "partition,genomes,modules,schema_ignore_params"
 }
 
 process {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -7,6 +7,7 @@ params {
   project = null
   clusterOptions = null
   schema_ignore_params = "genomes,input_paths,cluster-options,clusterOptions,project"
+  validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,schema_ignore_params"
   save_reference = true
   // Defaults set for Bianca - other clusters set below
   max_memory = 500.GB


### PR DESCRIPTION
schema_ignore_params has changed name to validationSchemaIgnoreParams at some point, support both names for now.
