### PR TITLE
fix typo vsc_kul_uhasselt.config

### DIFF
--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -53,7 +53,7 @@ profiles {
 
         process {
             executor = 'slurm'
-            queue = queue = {
+            queue = {
                 switch (task.memory) {
                 case { it >=  170.GB }: // 192 - 22
                     switch (task.time) {


### PR DESCRIPTION
Fixing a typo `queue = queue =`, weirdly enough this typo doesn't cause any issues? 

<!--
If you require/still waiting for a review, please feel free to request from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
