### PR TITLE
Incorrect overhead estimation vsc_kul_uhasselt

### DIFF
--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -46,7 +46,7 @@ profiles {
             config_profile_description = 'HPC_GENIUS profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 720.GB  // 768 - 48 so 48GB for overhead
+            max_memory = 703.GB  // 768 - 65 so 65GB for overhead, max is 720000MB
             max_time = 168.h
             max_cpus = 36
         }
@@ -55,7 +55,7 @@ profiles {
             executor = 'slurm'
             queue = {
                 switch (task.memory) {
-                case { it >=  170.GB }: // 192 - 22
+                case { it >=  175.GB }: // max is 180000
                     switch (task.time) {
                     case { it >= 72.h }:
                         return 'dedicated_big_bigmem'
@@ -81,7 +81,7 @@ profiles {
             config_profile_description = 'HPC_WICE profile for use on the Wice cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 2000.GB // 2048 - 48 so 48GB for overhead
+            max_memory = 1968.GB // max is 2016000
             max_cpus = 72
             max_time = 168.h
         }
@@ -90,7 +90,7 @@ profiles {
             executor = 'slurm'
             queue = {
                 switch (task.memory) {
-                case { it >=  220.GB }:  // 256 - 36
+                case { it >=  242.GB }:  // max is 248800
                     switch (task.time) {
                     case { it >= 72.h }:
                         return 'dedicated_big_bigmem'
@@ -116,7 +116,7 @@ profiles {
             config_profile_description = 'HPC_SUPERDOME profile for use on the genius cluster of the VSC HPC.'
             config_profile_contact = 'joon.klaps@kuleuven.be'
             config_profile_url = 'https://docs.vscentrum.be/en/latest/index.html'
-            max_memory = 708.GB // 756 - 48
+            max_memory = 5772.GB // 6000 - 228 so 228GB for overhead, max is 5910888MB
             max_cpus = 14
             max_time = 168.h
         }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -90,7 +90,7 @@ profiles {
             executor = 'slurm'
             queue = {
                 switch (task.memory) {
-                case { it >=  242.GB }:  // max is 248800
+                case { it >=  239.GB }:  // max is 244800
                     switch (task.time) {
                     case { it >= 72.h }:
                         return 'dedicated_big_bigmem'


### PR DESCRIPTION
Please follow these steps before submitting your PR:

- [X] Your PR targets the `master` branch
- [X] You've included links to relevant issues, if any
- [X] Requested review from @nf-core/maintainers and/or #request-review on slack

Some jobs were still requesting to much memory for a single node. I looked up the correct amounts through  `sinfo -N -l`. Which gave the exact limits (except for Wice, partition batch it was 244800MB instead of 248800MB). I tested all new memory limits
