### PR TITLE
Update eddie.config add BAM_MARKDUPLICATES_PICARD

### DIFF
--- a/conf/pipeline/rnaseq/eddie.config
+++ b/conf/pipeline/rnaseq/eddie.config
@@ -1,6 +1,6 @@
 process {
 
-withName : "PICARD_MARKDUPLICATES|QUALIMAP_RNASEQ|FASTQC|BBMAP_BBSPLIT" {
+withName : "PICARD_MARKDUPLICATES|QUALIMAP_RNASEQ|FASTQC|BBMAP_BBSPLIT|BAM_MARKDUPLICATES_PICARD" {
     clusterOptions = {"-l h_vmem=${(task.memory + 4.GB).bytes/task.cpus}"}
 }
 


### PR DESCRIPTION
Updated Univeristy of Edinburgh's HPC eddie.config for rnaseq pipelines to add extra memory to the process BAM_MARKDUPLICATES_PICARD