### PR TITLE
Update cambridge.config

### DIFF
--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -1,18 +1,24 @@
+// Description is overwritten with user specific flags
 params {
   config_profile_description = 'Cambridge HPC cluster profile.'
   config_profile_contact = 'Andries van Tonder (ajv37@cam.ac.uk)'
   config_profile_url = "https://docs.hpc.cam.ac.uk/hpc"
+  partition = null 
+  project = null
+  cacheDir = null
+  max_memory = 192.GB 
+  max_cpus = 56
+  max_time = 12.h 
 }
+
+// Description is overwritten with user specific flags 
 singularity {
   enabled = true
   autoMounts = true
-}
+  cacheDir = params.cacheDir
+} 
+
 process {
   executor = 'slurm'
-  clusterOptions = '-p cclake'
-}
-params {
-  max_memory = 192.GB
-  max_cpus = 56
-  max_time = 12.h
+  clusterOptions = "-A $params.project -p $params.partition"
 }


### PR DESCRIPTION
adding user-based options for selecting project and partition

---
name: Updated Config, much more adaptable
about: An existing cluster config
---

The three new parameters help the HPC user to set the partition, the project and Singularity cache, like so:
`nextflow run nf-core/sarek -profile test,cambridge.config --partition "cclake" --project "NAME-SL3-CPU" --cacheDir "/home/<username>/rds/hpc-work/path/to/cache/dir" --outdir nf-sarek-test`


<!--
If you require/still waiting for a review, please feel free to request from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
