### PR TITLE
Add codeowners generation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,7 +128,7 @@
 **uzh** @apeltzer
 **vai** @njspix
 **vsc_kul_uhasselt** @kuleuven.be' @kuleuven.be' @kuleuven.be'
-**vsc_ugent** @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be'
+**vsc_ugent** @nvnieuwk @matthdsm ict@cmgg.be
 **wcm** @DoaneAS
 **wehi** @wehi.edu.au
 **wustl_htcf** @wustl.edu>"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,135 @@
+**abims** @lecorguille
+**adcra** @kalayaneech
+**alice** @osteobjorn
+**apollo** @coh.org
+**aws_tower** @ggabernet
+**awsbatch** @apeltzer
+**azurebatch** @adamrtalbot
+**azurebatchdev** @abhi18av
+**bi** @apeltzer
+**bigpurple** @tobsecret
+**binac** @apeltzer
+**biohpc_gen** @phue
+**biowulf** @hpc.nih.gov'
+**cambridge** @cam.ac.uk
+**cbe** @phue
+**ccga_dx** @marchoeppner
+**ccga_med** @marchoeppner
+**cedars** @rajewski
+**ceres** @MillironX
+**cfc** @FriederikeHanssen
+**cfc_dev** @FriederikeHanssen
+**cheaha** @uab.edu
+**computerome** @marcmtk
+**crg** @joseespinosa
+**crick** @chris-cheshire
+**crukmi** @sppearce
+**czbiohub_aws** @olgabot
+**denbi_qbic** @apeltzer
+**dkfz** @dkfz-heidelberg.de'
+**ebc** @marcel-keller
+**ebi_codon** @saulpierotti-ebi
+**ebi_codon_slurm** @saulpierotti-ebi
+**eddie** @ameynert
+**engaging** @PhilPalmer
+**ethz_euler** @hest.ethz.ch
+**eva** @jfy133
+**fgcz** @fgcz.ethz.ch"
+**fub_curta** @zedat.fu-berlin.de'
+**genotoul** @inra.fr'
+**genouest** @abretaud
+**gis** @andreas-wilm
+**google** @evanfloden
+**googlebatch** @hnawar'
+**googlels** @hnawar'
+**hasta** config_profile_contact = 'Clinical Genomics, Stockholm'
+**hki** @jfy133 @jfy133 @jfy133 @jfy133
+**hypatia** @lusacristan
+**icr_davros** @adrlar
+**ifb_core** config_profile_contact = 'https://community.france-bioinformatique.fr'
+**imperial** @imperial.ac.uk
+**incliva** @incliva.es'
+**ipop_up** @parisepigenetics.com'
+**janelia** @janelia.hhmi.org
+**jax** @flynnb
+**ku_sund_dangpu** @sund.ku.dk>'
+**leicester** @cam.ac.uk'
+**lugh** @BarryDigby
+**maestro** @pierrespc
+**mana** config_profile_contact = 'Cedric Arisdakessian'
+**marvin** @gmail.com (Pablo Carrion
+**medair** @gu.se
+**mjolnir_globe** @ashildv
+**mpcdf** @jfy133
+**munin** @maxulysse
+**nci_gadi** @mattdton
+**nu_genomics** @NUjon
+**oist** @oist.jp>'
+**pasteur** @rplanel
+**pawsey_nimbus** @SarahBeecroft'
+**pawsey_setonix** @georgiesamaha
+**pdc_kth** @pontus
+**phoenix** @apeltzer
+**binac** @apeltzer
+**uppmax** @lnu.se
+**aws_tower** @emiller88
+**crick** @ChristopherBarrington
+**eva** @jfy133 @jfy133 @jfy133
+**maestro**
+**mpcdf** @jfy133 @jfy133
+**hki** @jfy133
+**engaging** @PhilPalmer
+**eva** @jfy133
+**crg** @joseespinosa
+**hasta**
+**hasta**
+**munin**
+**azurebatch_pools_Edv4** @vsmalladi
+**eddie**
+**mpcdf** @jfy133
+**utd_sysbio** @emiller88
+**munin** @praveenraj2018
+**cfc** @FriederikeHanssen
+**eddie**
+**eva** @jfy133
+**icr_davros**
+**munin** @maxulysse
+**uppmax** @MaxUlysse
+**imperial** config_profile_contact = 'NA'
+**eva** @jfy133
+**hasta** @sofstam
+**eddie**
+**genomes**
+**prince** @tobsecret
+**psmn** @l-modolo
+**rosalind** config_profile_contact = 'Theo Portlock'
+**rosalind_uge** @gregorysprenger
+**sage** @BrunoGrandePhD
+**sahmri** @sahmri.com
+**sanger** @priyanka-surana
+**scw** @bangor.ac.uk'
+**seawulf** @davidecarlson
+**seg_globe** @ashildv
+**software_license** @maxulysse
+**tigem** @giusmar
+**tubingen_apg** @sc13-bioinf
+**tuos_stanage** @sheffield.ac.uk
+**ucd_sonic** @brucemoran
+**ucl_myriad** @ucl.ac.uk
+**uct_hpc** @kviljoen
+**uge** @gregorysprenger
+**unc_lccc** @alanhoyle
+**unibe_ibu** @bioinformatics.unibe.ch"
+**uod_hpc** @dundee.ac.uk
+**uppmax** @ewels
+**utd_ganymede** @emiller88
+**utd_sysbio** @emiller88
+**uw_hyak_pedslabs** @CarsonJM
+**uzh** @apeltzer
+**vai** @njspix
+**vsc_kul_uhasselt** @kuleuven.be' @kuleuven.be' @kuleuven.be'
+**vsc_ugent** @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be' @cmgg.be'
+**wcm** @DoaneAS
+**wehi** @wehi.edu.au
+**wustl_htcf** @wustl.edu>"
+**xanadu** @uconn.edu'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ Please follow these steps before submitting your PR:
 - [ ] If your PR is a work in progress, include `[WIP]` in its title
 - [ ] Your PR targets the `master` branch
 - [ ] You've included links to relevant issues, if any
-- [ ] Requested review from @nf-core/maintainers and/or #request-review on slack
 
 Steps for adding a new config profile:
 
@@ -19,7 +18,7 @@ Steps for adding a new config profile:
 - [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
 
 <!--
-If you require/still waiting for a review, please feel free to request from @nf-core/maintainers
+If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers
 
 Please see uploading to`nf-core/configs` for more details:
 https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

--- a/.github/generate_codeowners.sh
+++ b/.github/generate_codeowners.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+CONFIGS=$(fd . -e .config 'conf/')
+
+output_file=".github/CODEOWNERS"
+rm $output_file
+
+for file in $CONFIGS; do
+    # Get the line of the file that starts with config_profile_contact
+    line=$(rg "config_profile_contact" "$file")
+    # and then get the username after the @ and remove anything after it
+    username=$(echo "$line" | sed 's/^.*@/@/g')
+    # Remove the )'
+    username=$(echo "$username" | sed 's/).*$//g')
+
+    # Get the insitute name
+    # conf/<institute>.config
+    institute=$(echo "$file" | sed 's/^.*\///g' | sed 's/\.config$//g')
+
+    # # Remove quotes from authors
+    echo "**$institute**" $username >> $output_file
+done


### PR DESCRIPTION
Proposing we use this, and then set up review reminders in Slack, so when a PR goes stale(for say 3 days?) it'll then request maintainers on it. We could also flip on the load balancing on, and randomly assign a maintainer to do the initial review for new profiles that don't have a CODEOWNER.

Right now I get an @ every PR, which is just noisy. I'd rather know that I really am needed to review something.

