### PR TITLE
FUB Curta Profile Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Currently documentation is available for the following pipelines within specific
 - mag
   - [Engaging](docs/pipeline/mag/engaging.md)
   - [EVA](docs/pipeline/mag/eva.md)
+- methylseq
+  - [FUB Curta](docs/pipeline/methylseq/fub_curta.md)
 - rnafusion
   - [HASTA](docs/pipeline/rnafusion/hasta.md)
   - [MUNIN](docs/pipeline/rnafusion/munin.md)

--- a/conf/fub_curta.config
+++ b/conf/fub_curta.config
@@ -17,6 +17,7 @@ def membership = ['/bin/bash', '-c', 'groups'].execute().text.trim()
 process {
     executor = 'slurm'
     maxRetries = 3
+    stageInMode = 'copy'
     clusterOptions = { (membership.startsWith("b") ? '--partition=begendiv,main ' : '--partition=main ') << ( task.time <= 3.h ? '--qos=hiprio' : ( task.time <= 3.d ? '--qos=prio' : '--qos=standard' ) ) }
 }
 

--- a/conf/fub_curta.config
+++ b/conf/fub_curta.config
@@ -6,9 +6,8 @@ params {
     config_profile_url = 'https://www.fu-berlin.de/en/sites/high-performance-computing/index.html'
 
     max_cpus = 32
-    max_memory = 385.GB
+    max_memory = 772.GB
     max_time = 14.d
-    // These parameters exclude the 4 x 772.GB compute nodes on 'main'
 }
 
 def membership = ['/bin/bash', '-c', 'groups'].execute().text.trim()

--- a/conf/fub_curta.config
+++ b/conf/fub_curta.config
@@ -16,7 +16,6 @@ def membership = ['/bin/bash', '-c', 'groups'].execute().text.trim()
 process {
     executor = 'slurm'
     maxRetries = 3
-    stageInMode = 'copy'
     clusterOptions = { (membership.startsWith("b") ? '--partition=begendiv,main ' : '--partition=main ') << ( task.time <= 3.h ? '--qos=hiprio' : ( task.time <= 3.d ? '--qos=prio' : '--qos=standard' ) ) }
 }
 

--- a/conf/pipeline/methylseq/fub_curta.config
+++ b/conf/pipeline/methylseq/fub_curta.config
@@ -1,0 +1,11 @@
+// Config profile metadata
+params {
+    config_profile_contact = 'Wassim Salam (@wassimsalam01)'
+    config_profile_description = 'nf-core/methylseq fub_curta profile provided by nf-core/configs'
+}
+
+process {
+    withName: 'NFCORE_METHYLSEQ:METHYLSEQ:PREPARE_GENOME:BISMARK_GENOMEPREPARATION' {
+        stageInMode = 'copy'
+    }
+}

--- a/docs/fub_curta.md
+++ b/docs/fub_curta.md
@@ -1,4 +1,4 @@
-# nf-core/configs: Freie Universiät Berlin High-Performance Computer (Curta) Configuration
+# nf-core/configs: Freie Universität Berlin High-Performance Computer (Curta) Configuration
 
 > **NB:** In order to run pipelines using this HPC cluster, you must first apply for access [here](https://ssl2.cms.fu-berlin.de/fu-berlin/en/sites/high-performance-computing/PM_Zugang-beantragen/index.html).
 

--- a/docs/fub_curta.md
+++ b/docs/fub_curta.md
@@ -24,6 +24,10 @@ In addition, job submissions are assigned the appropriate quality of service (QO
 - `prio` for `task.time <= 3.d`
 - `standard` for `task.time <= 14.d`
 
+Institute-specific pipeline profiles exists for:
+
+- [methylseq](pipeline/methylseq/fub_curta.md)
+
 ## debug profile
 
 Deactivating the cleanup of intermediate files is also possible. It is done by specifying `-profile fub_curta,debug`. This simply turns off automatic clean up of intermediate files, which can be useful for debugging.

--- a/docs/fub_curta.md
+++ b/docs/fub_curta.md
@@ -16,7 +16,7 @@ module load Nextflow
 
 Using `-profile fub_curta` will download the config file, which has been pre-configured with a setup suitable for the Curta cluster.
 
-The default partition for job submissions is `main`. With the current `max_memory` settings, the user has access to 162 nodes on `main`. The profile automatically detects whether the user belongs to the BeGenDiv working group, and gives the user access to 4 more nodes by making use of the `begendiv` partition together with `main`, giving precedence to the former.
+The default partition for job submissions is `main`. The user has access to 166 nodes on `main`. The profile automatically detects whether the user belongs to the BeGenDiv working group, and gives the user access to 4 more nodes by making use of the `begendiv` partition together with `main`, giving precedence to the former.
 
 In addition, job submissions are assigned the appropriate quality of service (QOS) as such:
 

--- a/docs/fub_curta.md
+++ b/docs/fub_curta.md
@@ -1,4 +1,4 @@
-# nf-core/configs: Freie Universität Berlin High-Performance Computer (Curta) Configuration
+# nf-core/configs: Freie Universität Berlin _Curta_ Configuration
 
 > **NB:** In order to run pipelines using this HPC cluster, you must first apply for access [here](https://ssl2.cms.fu-berlin.de/fu-berlin/en/sites/high-performance-computing/PM_Zugang-beantragen/index.html).
 

--- a/docs/fub_curta.md
+++ b/docs/fub_curta.md
@@ -2,7 +2,7 @@
 
 > **NB:** In order to run pipelines using this HPC cluster, you must first apply for access [here](https://ssl2.cms.fu-berlin.de/fu-berlin/en/sites/high-performance-computing/PM_Zugang-beantragen/index.html).
 
-Job limits are capped at 32 CPUs, 385 GB and a maximum run time of 14 days.
+Job limits are capped at 32 CPUs, 772 GB and a maximum run time of 14 days.
 
 This profile is configured to run with Apptainer, which is pre-loaded and globally available to all users on the cluster.
 
@@ -11,6 +11,8 @@ First, Nextflow should be loaded into your interactive session or added to your 
 ```bash
 module load Nextflow
 ```
+
+> Note: There exists different version modules for Nextflow on the cluster. This command ensures loading the latest version.
 
 Using `-profile fub_curta` will download the config file, which has been pre-configured with a setup suitable for the Curta cluster.
 

--- a/docs/pipeline/methylseq/fub_curta.md
+++ b/docs/pipeline/methylseq/fub_curta.md
@@ -1,0 +1,17 @@
+# nf-core/configs: fub_curta methylseq specific configuration
+
+Extra specific configuration for methylseq pipeline
+
+## Usage
+
+To use, run the pipeline with `-profile fub_curta`.
+
+This will download and launch the methylseq specific [`fub_curta.config`](../../../conf/pipeline/methylseq/fub_curta.config) which has been pre-configured with a setup suitable for the `FUB Curta` cluster.
+
+Example: `nextflow run nf-core/methylseq -profile fub_curta`
+
+## methylseq specific configurations for fub_curta
+
+Specific configurations for fub_curta has been made for methylseq.
+
+- The general FUB Curta profile runs with default nf-core/methylseq parameters, but with `stageInMode = copy` in `'NFCORE_METHYLSEQ:METHYLSEQ:PREPARE_GENOME:BISMARK_GENOMEPREPARATION'`. This is due to an error whereby methylseq wouldn't detect the genome with the default `stageInMode = symlink` (see [Slack Thread](https://nfcore.slack.com/archives/CP3RJSMF0/p1701631528797349?thread_ts=1699299636.564489&cid=CP3RJSMF0) and [#305](https://github.com/nf-core/methylseq/issues/305))

--- a/pipeline/methylseq.config
+++ b/pipeline/methylseq.config
@@ -7,3 +7,7 @@
  * in the conf/pipeline/methylseq folder and imported
  * under a profile name here.
  */
+
+profiles {
+  fub_curta { includeConfig "${params.custom_config_base}/conf/pipeline/methylseq/fub_curta.config" }
+}


### PR DESCRIPTION
- [x] Your PR targets the `master` branch

List of changes and reasoning:
- Increased `max_memory` to make it possible to use the 4 x 772.GB nodes available in `main` partition on the cluster
- Overrode the default 'symlink' `stageInMode` with 'copy' due to errors with some processes in the pipeline (in my case Bismark genome preparation in `methylseq -r 2.4.0`) ([see this Slack thread](https://nfcore.slack.com/archives/CP3RJSMF0/p1699299636564489))