### PR TITLE
Check if task.attempt isn't empty

### DIFF
--- a/conf/vsc_ugent.config
+++ b/conf/vsc_ugent.config
@@ -41,7 +41,7 @@ executor {
 process {
     stageInMode = "symlink"
     stageOutMode = "rsync"
-    errorStrategy = { sleep(Math.pow(2, task.attempt) * 200 as long); return 'retry' }
+    errorStrategy = { sleep(Math.pow(2, task.attempt ?: 1) * 200 as long); return 'retry' }
     maxRetries    = 5
 }
 


### PR DESCRIPTION
This change checks if `task.attempt` is empty `[:]`. If so, it defaults to `1`.

This to fix this error from popping up when a process fails before it has even started:
```
groovy.lang.MissingMethodException: No signature of method: static java.lang.Math.pow() is applicable fo
r argument types: (Integer, ConfigObject) values: [2, [:]]
```