### PR TITLE
Update nyu_hpc.md

### DIFF
--- a/docs/nyu_hpc.md
+++ b/docs/nyu_hpc.md
@@ -2,11 +2,9 @@
 
 All nf-core pipelines have been successfully configured for use on the HPC Cluster at New York University.
 
-To use, run the pipeline with `-profile nyu_hpc`. This will download and launch the [`profile.config`](../conf/profile.config) which has been pre-configured with a setup suitable for the NYU HPC cluster. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
+To use, run the pipeline with `-profile nyu_hpc`. This will download and launch the [`nyu_hpc.config`](../conf/nyu_hpc.config) which has been pre-configured with a setup suitable for the NYU HPC cluster. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Singularity image before execution of the pipeline.
 
-## Below are non-mandatory information e.g. on modules to load etc
-
-Before running the pipeline you will need to load Nextflow and Singularity using the environment module system on PROFILE CLUSTER. You can do this by issuing the commands below:
+Before running the pipeline you will need to load Nextflow using the environment module system on NYU HPC. You can do this by issuing the commands below:
 
 ```bash
 ## Load Nextflow modules


### PR DESCRIPTION
fixed link and cleared up text for NYU HPC config.
