### PR TITLE
New config for VSC CalcUA (UAntwerp)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,7 @@ jobs:
           - "uzh"
           - "uzl_omics"
           - "vai"
+          - "vsc_calcua"
           - "vsc_kul_uhasselt"
           - "vsc_ugent"
           - "wehi"

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Currently documentation is available for the following systems:
 - [UZH](docs/uzh.md)
 - [UZL_OMICS](docs/uzl_omics.md)
 - [VAI](docs/vai.md)
+- [VSC_CALCUA](docs/vsc_calcua.md)
 - [VSC_KUL_UHASSELT](docs/vsc_kul_uhasselt.md)
 - [VSC_UGENT](docs/vsc_ugent.md)
 - [WEHI](docs/wehi.md)

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -155,6 +155,9 @@ profiles {
         process {
             executor = 'slurm'
             queue = 'broadwell'
+            // Select regular or high memory nodes depending on current pipeline task.
+            // See: https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html
+            clusterOptions = { check_max(task.mem) >= 112.GB ? "--constraint=mem256" : "--constraint=mem128"}
         }
         executor {
             exitReadTimeout = "3days"

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -47,12 +47,11 @@ def partition_checker(String profile) {
 // Reduce the job submit rate to about 30 per minute, this way the server
 // won't be bombarded with jobs.
 // Limit queueSize to keep job rate under control and avoid timeouts.
-// Extend the exit read timeout to 3 days (= wall time of vaughan and leibniz).
+// Also see extendReadTimeout setting under each of the partition profiles.
 // See: https://www.nextflow.io/docs/latest/config.html#scope-executor
 executor {
     submitRateLimit = '30/1min'
     queueSize = 10
-    exitReadTimeout = "3day"
 }
 
 // Add backoff strategy to catch cluster timeouts and proper symlinks of files in scratch
@@ -111,6 +110,9 @@ profiles {
             executor = 'slurm'
             queue = 'zen2'
         }
+        executor {
+            exitReadTimeout = "3days"
+        }
     }
     zen2_single {
         params {
@@ -123,6 +125,9 @@ profiles {
         }
         process {
             executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "3days"
         }
         partition_checker("zen2")
     }
@@ -141,6 +146,9 @@ profiles {
             executor = 'slurm'
             queue = 'broadwell'
         }
+        executor {
+            exitReadTimeout = "3days"
+        }
     }
     broadwell_single {
         params {
@@ -153,6 +161,9 @@ profiles {
         }
         process {
             executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "3days"
         }
         partition_checker("broadwell")
     }
@@ -171,6 +182,9 @@ profiles {
             executor = 'slurm'
             queue = 'skylake'
         }
+        executor {
+            exitReadTimeout = "7days"
+        }
     }
     skylake_single {
         params {
@@ -183,6 +197,9 @@ profiles {
         }
         process {
             executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "7days"
         }
         partition_checker("skylake")
     }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -1,0 +1,53 @@
+// Define the scratch directory, which will be used for storing the nextflow
+// work directory and for caching apptainer/singularity files.
+// Default to /tmp directory if $VSC_SCRATCH scratch env is not available,
+// see: https://github.com/nf-core/configs?tab=readme-ov-file#adding-a-new-config
+def scratch_dir = System.getenv("VSC_SCRATCH") ?: "/tmp"
+
+// Specify the work directory.
+workDir = "$scratch_dir/work"
+
+// Perform work directory cleanup when the run has succesfully completed.
+cleanup = true
+
+// Reduce the job submit rate to about 30 per minute, this way the server
+// won't be bombarded with jobs.
+// Limit queueSize to keep job rate under control and avoid timeouts.
+// Extend the exit read timeout to 3 days (= wall time of vaughan and leibniz).
+// See: https://www.nextflow.io/docs/latest/config.html#scope-executor
+executor {
+    submitRateLimit = '30/1min'
+    queueSize = 10
+    exitReadTimeout = "3day"
+}
+
+// Add backoff strategy to catch cluster timeouts and proper symlinks of files in scratch
+// to the work directory.
+// See: https://www.nextflow.io/docs/latest/config.html#scope-process
+process {
+    stageInMode = "symlink"
+    stageOutMode = "rsync"
+    errorStrategy = { sleep(Math.pow(2, task.attempt ?: 1) * 200 as long); return 'retry' }
+    maxRetries = 5
+}
+
+// Specify that apptainer/singularity should be used and where the cache dir will be for the images.
+// The singularity directive is used in favour of the apptainer one, because currently the apptainer
+// variant will pull in (and convert) docker images, instead of using pre-built singularity ones.
+// To use the pre-built singularity containers instead, the singularity options should be selected
+// with apptainer installed on the system, which defines singularity as an alias (as is the case
+// on CalcUA).
+// See https://nf-co.re/docs/usage/installation#pipeline-software
+// and https://nf-co.re/tools#how-the-singularity-image-downloads-work
+// See https://www.nextflow.io/docs/latest/config.html#scope-singularity
+singularity {
+    enabled = true
+    autoMounts = true
+    // See https://www.nextflow.io/docs/latest/singularity.html#singularity-docker-hub
+    cacheDir = "$scratch_dir/apptainer/nextflow_cache"  // Equivalent to NXF_APPTAINER_CACHEDIR/NXF_SINGULARITY_CACHEDIR
+}
+
+// AWS maximum retries for errors (This way the pipeline doesn't fail if the download fails one time)
+aws {
+    maxErrorRetry = 3
+}

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -148,16 +148,13 @@ profiles {
             config_profile_description = 'Broadwell Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = 240.GB // 128 GB (total) - 16 GB (buffer) (or 256 - 16 GB for the mem256 nodes)
+            max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
             max_cpus = 28
             max_time = '3days'
         }
         process {
             executor = 'slurm'
             queue = 'broadwell'
-            // Select regular or high memory nodes depending on current pipeline task.
-            // See: https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html
-            clusterOptions = { check_max(task.mem) >= 112.GB ? "--constraint=mem256" : "--constraint=mem128"}
         }
         executor {
             exitReadTimeout = "3days"
@@ -179,6 +176,40 @@ profiles {
             exitReadTimeout = "3days"
         }
         partition_checker("broadwell")
+    }
+    broadwell_256 {
+        params {
+            config_profile_description = 'Broadwell_256 Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
+            max_memory = 240.GB // 256 (total) - 16 GB (buffer)
+            max_cpus = 28
+            max_time = '3days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'broadwell_256'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+    }
+    broadwell_256_single {
+        params {
+            config_profile_description = 'Broadwell_256 single node profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
+            max_memory = 240.GB // 256 (total) - 16 GB (buffer)
+            max_cpus = 28
+            max_time = '3days'
+        }
+        process {
+            executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+        partition_checker("broadwell_256")
     }
 
     // Breniac (previously Hopper) partitions

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -127,8 +127,8 @@ profiles {
             config_profile_description = 'Zen2 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(64)
             max_time = 3.days
         }
         process {
@@ -161,8 +161,8 @@ profiles {
             config_profile_description = 'Zen3 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(64)
             max_time = 3.days
         }
         process {
@@ -195,8 +195,8 @@ profiles {
             config_profile_description = 'Zen3_512 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            max_memory = get_allocated_mem(496) // 512 GB (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(64)
             max_time = 3.days
         }
         process {
@@ -230,8 +230,8 @@ profiles {
             config_profile_description = 'Broadwell local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
-            max_cpus = 28
+            max_memory = get_allocated_mem(112) // 128 GB (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(28)
             max_time = 3.days
         }
         process {
@@ -264,8 +264,8 @@ profiles {
             config_profile_description = 'Broadwell_256 local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = 240.GB // 256 (total) - 16 GB (buffer)
-            max_cpus = 28
+            max_memory = get_allocated_mem(240) // 256 (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(28)
             max_time = 3.d
         }
         process {
@@ -299,8 +299,8 @@ profiles {
             config_profile_description = 'Skylake local profile for use on a single node of the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
-            max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
-            max_cpus = 28
+            max_memory = get_allocated_mem(176) // 192 GB (total) - 16 GB (buffer)
+            max_cpus = get_allocated_cpus(28)
             max_time = 7.days
         }
         process {
@@ -317,4 +317,24 @@ profiles {
     debug {
         cleanup = false
     }
+}
+
+// Define functions to fetch the available CPUs and memory of the current execution node.
+// Only used when running one of the *_local partition profiles and allows the cpu
+// and memory thresholds to be set dynamic based on the available hardware as reported
+// by Slurm. Can be supplied with a default return value, which should be set to the
+// recommended thresholds for the particular partition's node types.
+def get_allocated_cpus(int node_max_cpu) {
+    max_cpus = System.getenv("SLURM_CPUS_PER_TASK") ?: System.getenv("SLURM_JOB_CPUS_PER_NODE") ?: node_max_cpu
+    return max_cpus.toInteger()
+}
+def get_allocated_mem(int node_max_mem) {
+    def mem_per_cpu = System.getenv("SLURM_MEM_PER_CPU")
+    def cpus_per_task = System.getenv("SLURM_CPUS_PER_TASK") ?: System.getenv("SLURM_JOB_CPUS_PER_NODE")
+
+    if ( mem_per_cpu && cpus_per_task ) {
+        node_max_mem = mem_per_cpu.toInteger() / 1000 * cpus_per_task.toInteger()
+    }
+
+    return "${node_max_mem}.GB" as nextflow.util.MemoryUnit
 }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -91,12 +91,12 @@ singularity {
     enabled = true
     autoMounts = true
     // See https://www.nextflow.io/docs/latest/singularity.html#singularity-docker-hub
-    cacheDir = "$scratch_dir/apptainer/nextflow_cache"  // Equivalent to NXF_APPTAINER_CACHEDIR/NXF_SINGULARITY_CACHEDIR
+    cacheDir = "$scratch_dir/apptainer/nextflow_cache"  // Equivalent to setting NXF_APPTAINER_CACHEDIR/NXF_SINGULARITY_CACHEDIR environment variable
 }
 
 // Define profiles for the following partitions:
-// - zen2 (Vaughan)
-// - broadwell (Leibniz)
+// - zen2, zen3, zen3_512 (Vaughan)
+// - broadwell, broadwell_256 (Leibniz)
 // - skylake (Breniac, formerly Hopper)
 // For each partition, there is a "*_slurm" profile and a "*_local" profile.
 // The former uses the slurm executor to submit each nextflow task as a separate job,
@@ -207,8 +207,6 @@ profiles {
         }
         partition_checker("zen3_512")
     }
-
-
     // Leibniz partitions
     broadwell_slurm {
         params {
@@ -278,7 +276,6 @@ profiles {
         }
         partition_checker("broadwell_256")
     }
-
     // Breniac (previously Hopper) partitions
     skylake_slurm {
         params {
@@ -314,8 +311,8 @@ profiles {
         }
         partition_checker("skylake")
     }
-
     // debug profile that does not automatically discard files in the work directory.
+    // Can be combined with any of the above profiles for easier debugging and tracing of runs.
     // See: https://nf-co.re/docs/usage/tutorials/step_by_step_institutional_profile#if-your-cluster-often-have-too-full-harddisk-space-issues
     debug {
         cleanup = false

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -40,9 +40,8 @@ if ( host_is_calcua() ) {
 
 // Function to check if the selected partition profile matches the partition on which the master
 // nextflow job was launched (either implicitly or via `sbatch --partition=<partition-name>`).
-// If the profile type is `*_single` and the partitions do not match, stop the execution and
+// If the profile type is `*_local` and the partitions do not match, stop the execution and
 // warn the user.
-// Only applies to the `*_single` profile types.
 def partition_checker(String profile) {
     // Skip check if host machine is not CalcUA, in order to not hinder github actions.
     if (! host_is_calcua() ) {
@@ -54,7 +53,7 @@ def partition_checker(String profile) {
         System.err.println("\nWARNING: Current partition could not be found in the expected \$SLURM_JOB_PARTITION environment variable. Please make sure that you submit your pipeline via a Slurm job instead of running the nextflow command directly on a login node.\nExiting...\n")
         System.exit(1)
     } else if ( current_partition != profile) {
-        System.err.println("\nWARNING: Slurm job was launched on the \'$current_partition\' partition, but the selected nextflow profile points to the $profile partition instead ('${profile}_single'). When using one of the single node execution profiles, please launch the job on the corresponding partition in Slurm.\nE.g., Slurm job submission command:\n    sbatch --account <project_account> --partition=broadwell script.slurm\nand job script containing a nextflow command with matching profile section:\n    nextflow run <pipeline> -profile vsc_calcua,broadwell_single\nExiting...\n")
+        System.err.println("\nWARNING: Slurm job was launched on the \'$current_partition\' partition, but the selected nextflow profile points to the $profile partition instead ('${profile}_local'). When using one of the local node execution profiles, please launch the job on the corresponding partition in Slurm.\nE.g., Slurm job submission command:\n    sbatch --account <project_account> --partition=broadwell script.slurm\nand job script containing a nextflow command with matching profile section:\n    nextflow run <pipeline> -profile vsc_calcua,broadwell_local\nExiting...\n")
         System.exit(1)
     }
 }
@@ -99,15 +98,14 @@ singularity {
 // - zen2 (Vaughan)
 // - broadwell (Leibniz)
 // - skylake (Breniac, formerly Hopper)
-// For each partition, there is both a regular profile (named after the partition)
-// and a single node profile (named with "*_single" suffix).
+// For each partition, there is a "*_slurm" profile and a "*_local" profile.
 // The former uses the slurm executor to submit each nextflow task as a separate job,
-// whereas the latter runs all tasks on the same local node on which the nextflow
-// head process was launched.
+// whereas the latter runs all tasks on the individual node on which the nextflow
+// master process was launched.
 // See: https://www.nextflow.io/docs/latest/config.html#config-profiles
 profiles {
     // Vaughan partitions
-    zen2 {
+    zen2_slurm {
         params {
             config_profile_description = 'Zen2 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -124,9 +122,9 @@ profiles {
             exitReadTimeout = "3days"
         }
     }
-    zen2_single {
+    zen2_local {
         params {
-            config_profile_description = 'Zen2 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Zen2 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
@@ -141,7 +139,7 @@ profiles {
         }
         partition_checker("zen2")
     }
-    zen3 {
+    zen3_slurm {
         params {
             config_profile_description = 'Zen3 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -158,9 +156,9 @@ profiles {
             exitReadTimeout = "3days"
         }
     }
-    zen3_single {
+    zen3_local {
         params {
-            config_profile_description = 'Zen3 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Zen3 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
@@ -175,7 +173,7 @@ profiles {
         }
         partition_checker("zen3")
     }
-    zen3_512 {
+    zen3_512_slurm {
         params {
             config_profile_description = 'Zen3_512 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -192,9 +190,9 @@ profiles {
             exitReadTimeout = "3days"
         }
     }
-    zen3_512_single {
+    zen3_512_local {
         params {
-            config_profile_description = 'Zen3_512 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Zen3_512 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
@@ -212,7 +210,7 @@ profiles {
 
 
     // Leibniz partitions
-    broadwell {
+    broadwell_slurm {
         params {
             config_profile_description = 'Broadwell Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -229,9 +227,9 @@ profiles {
             exitReadTimeout = "3days"
         }
     }
-    broadwell_single {
+    broadwell_local {
         params {
-            config_profile_description = 'Broadwell single node profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Broadwell local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
@@ -246,7 +244,7 @@ profiles {
         }
         partition_checker("broadwell")
     }
-    broadwell_256 {
+    broadwell_256_slurm {
         params {
             config_profile_description = 'Broadwell_256 Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -263,9 +261,9 @@ profiles {
             exitReadTimeout = "3days"
         }
     }
-    broadwell_256_single {
+    broadwell_256_local {
         params {
-            config_profile_description = 'Broadwell_256 single node profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Broadwell_256 local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 240.GB // 256 (total) - 16 GB (buffer)
@@ -282,7 +280,7 @@ profiles {
     }
 
     // Breniac (previously Hopper) partitions
-    skylake {
+    skylake_slurm {
         params {
             config_profile_description = 'Skylake Slurm profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
@@ -299,9 +297,9 @@ profiles {
             exitReadTimeout = "7days"
         }
     }
-    skylake_single {
+    skylake_local {
         params {
-            config_profile_description = 'Skylake single node profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
+            config_profile_description = 'Skylake local profile for use on a single node of the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
             config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
             max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -51,3 +51,102 @@ singularity {
 aws {
     maxErrorRetry = 3
 }
+
+// Define profiles for the following partitions:
+// - zen2 (Vaughan)
+// - broadwell (Leibniz)
+// - skylake (Breniac, formerly Hopper)
+// For each partition, there is both a regular profile (named after the partition)
+// and a single node profile (named with "*_single" suffix).
+// The former uses the slurm executor to submit each nextflow task as a separate job,
+// whereas the latter runs all tasks on the same local node on which the nextflow
+// head process was launched.
+// See: https://www.nextflow.io/docs/latest/config.html#config-profiles
+profiles {
+    // Vaughan partitions
+    zen2 {
+        params {
+            config_profile_description = 'Zen2 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'zen2'
+        }
+    }
+    zen2_single {
+        params {
+            config_profile_description = 'Zen2 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'local'
+        }
+    }
+
+    // Leibniz partitions
+    broadwell {
+        params {
+            config_profile_description = 'Broadwell Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
+            max_memory = 240.GB // 128 GB (total) - 16 GB (buffer) (or 256 - 16 GB for the mem256 nodes)
+            max_cpus = 28
+            max_time = '3days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'broadwell'
+        }
+    }
+    broadwell_single {
+        params {
+            config_profile_description = 'Broadwell single node profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
+            max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
+            max_cpus = 28
+            max_time = '3days'
+        }
+        process {
+            executor = 'local'
+        }
+    }
+
+    // Breniac (previously Hopper) partitions
+    skylake {
+        params {
+            config_profile_description = 'Skylake Slurm profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
+            max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
+            max_cpus = 28
+            max_time = '7days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'skylake'
+        }
+    }
+    skylake_single {
+        params {
+            config_profile_description = 'Skylake single node profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
+            max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
+            max_cpus = 28
+            max_time = '7days'
+        }
+        process {
+            executor = 'local'
+        }
+    }
+}

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -141,6 +141,75 @@ profiles {
         }
         partition_checker("zen2")
     }
+    zen3 {
+        params {
+            config_profile_description = 'Zen3 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'zen3'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+    }
+    zen3_single {
+        params {
+            config_profile_description = 'Zen3 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+        partition_checker("zen3")
+    }
+    zen3_512 {
+        params {
+            config_profile_description = 'Zen3_512 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'slurm'
+            queue = 'zen3_512'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+    }
+    zen3_512_single {
+        params {
+            config_profile_description = 'Zen3_512 single node profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
+            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
+            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
+            max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
+            max_cpus = 64
+            max_time = '3days'
+        }
+        process {
+            executor = 'local'
+        }
+        executor {
+            exitReadTimeout = "3days"
+        }
+        partition_checker("zen3_512")
+    }
+
 
     // Leibniz partitions
     broadwell {

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -198,4 +198,10 @@ profiles {
         }
         partition_checker("skylake")
     }
+
+    // debug profile that does not automatically discard files in the work directory.
+    // See: https://nf-co.re/docs/usage/tutorials/step_by_step_institutional_profile#if-your-cluster-often-have-too-full-harddisk-space-issues
+    debug {
+        cleanup = false
+    }
 }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -10,6 +10,22 @@ workDir = "$scratch_dir/work"
 // Perform work directory cleanup when the run has succesfully completed.
 cleanup = true
 
+// Function to check if the selected partition profile matches the partition on which the master
+// nextflow job was launched (either implicitly or via `sbatch --partition=<partition-name>`).
+// If the profile type is `*_single` and the partitions do not match, stop the execution and
+// warn the user.
+// Only applies to the `*_single` profile types.
+def partition_checker(String profile) {
+    def current_partition = System.getenv("SLURM_JOB_PARTITION")
+    if (! current_partition) {
+        System.err.println("\nWARNING: Current partition could not be found in the expected \$SLURM_JOB_PARTITION environment variable. Please make sure that you submit your pipeline via a Slurm job instead of running the nextflow command directly on a login node.\nExiting...\n")
+        System.exit(1)
+    } else if ( current_partition != profile) {
+        System.err.println("\nWARNING: Slurm job was launched on the \'$current_partition\' partition, but the selected nextflow profile points to the $profile partition instead ('${profile}_single'). When using one of the single node execution profiles, please launch the job on the corresponding partition in Slurm.\nE.g., Slurm job submission command:\n    sbatch --account <project_account> --partition=broadwell script.slurm\nand job script containing a nextflow command with matching profile section:\n    nextflow run <pipeline> -profile vsc_calcua,broadwell_single\nExiting...\n")
+        System.exit(1)
+    }
+}
+
 // Reduce the job submit rate to about 30 per minute, this way the server
 // won't be bombarded with jobs.
 // Limit queueSize to keep job rate under control and avoid timeouts.
@@ -90,6 +106,7 @@ profiles {
         process {
             executor = 'local'
         }
+        partition_checker("zen2")
     }
 
     // Leibniz partitions
@@ -119,6 +136,7 @@ profiles {
         process {
             executor = 'local'
         }
+        partition_checker("broadwell")
     }
 
     // Breniac (previously Hopper) partitions
@@ -148,5 +166,6 @@ profiles {
         process {
             executor = 'local'
         }
+        partition_checker("skylake")
     }
 }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -80,11 +80,6 @@ singularity {
     cacheDir = "$scratch_dir/apptainer/nextflow_cache"  // Equivalent to NXF_APPTAINER_CACHEDIR/NXF_SINGULARITY_CACHEDIR
 }
 
-// AWS maximum retries for errors (This way the pipeline doesn't fail if the download fails one time)
-aws {
-    maxErrorRetry = 3
-}
-
 // Define profiles for the following partitions:
 // - zen2 (Vaughan)
 // - broadwell (Leibniz)

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -10,6 +10,22 @@ workDir = "$scratch_dir/work"
 // Perform work directory cleanup when the run has succesfully completed.
 cleanup = true
 
+// Check if APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variables are set.
+// If they are available, try to create the tmp directory at the specified location.
+def apptainer_tmpdir = System.getenv("APPTAINER_TMPDIR") ?: System.getenv("SINGULARITY_TMPDIR") ?: null
+if (! apptainer_tmpdir ) {
+    System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local ${TMPDIR} (or /tmp) on the main execution node.\n")
+} else {
+    apptainer_tmpdir = new File(apptainer_tmpdir)
+    if (! apptainer_tmpdir.exists() ) {
+        dir_created = apptainer_tmpdir.mkdirs()
+        if (! dir_created ) {
+            System.err.println("\nWARNING: Could not create directory at the location specified by APPTAINER_TMPDIR/SINGULARITY_TMPDIR: $apptainer_tmpdir\nPlease check if this is a valid path to which you have write permission. Exiting...\n")
+            System.exit(1)
+        }
+    }
+}
+
 // Function to check if the selected partition profile matches the partition on which the master
 // nextflow job was launched (either implicitly or via `sbatch --partition=<partition-name>`).
 // If the profile type is `*_single` and the partitions do not match, stop the execution and

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -112,14 +112,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'slurm'
             queue = 'zen2'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
     }
     zen2_local {
@@ -129,13 +129,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
         partition_checker("zen2")
     }
@@ -146,14 +146,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'slurm'
             queue = 'zen3'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
     }
     zen3_local {
@@ -163,13 +163,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
         partition_checker("zen3")
     }
@@ -180,14 +180,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'slurm'
             queue = 'zen3_512'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
     }
     zen3_512_local {
@@ -197,13 +197,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
         partition_checker("zen3_512")
     }
@@ -215,14 +215,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'slurm'
             queue = 'broadwell'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
     }
     broadwell_local {
@@ -232,13 +232,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
         partition_checker("broadwell")
     }
@@ -249,14 +249,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 240.GB // 256 (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '3days'
+            max_time = 3.days
         }
         process {
             executor = 'slurm'
             queue = 'broadwell_256'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
     }
     broadwell_256_local {
@@ -266,13 +266,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 240.GB // 256 (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '3days'
+            max_time = 3.d
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "3days"
+            exitReadTimeout = 3.days
         }
         partition_checker("broadwell_256")
     }
@@ -284,14 +284,14 @@ profiles {
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
             max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '7days'
+            max_time = 7.days
         }
         process {
             executor = 'slurm'
             queue = 'skylake'
         }
         executor {
-            exitReadTimeout = "7days"
+            exitReadTimeout = 7.days
         }
     }
     skylake_local {
@@ -301,13 +301,13 @@ profiles {
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
             max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = '7days'
+            max_time = 7.days
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = "7days"
+            exitReadTimeout = 7.days
         }
         partition_checker("skylake")
     }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -14,7 +14,9 @@ cleanup = true
 // If they are available, try to create the tmp directory at the specified location.
 def apptainer_tmpdir = System.getenv("APPTAINER_TMPDIR") ?: System.getenv("SINGULARITY_TMPDIR") ?: null
 if (! apptainer_tmpdir ) {
-    System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local ${TMPDIR} (or /tmp) on the main execution node.\n")
+    def tmp_dir = System.getenv("TMPDIR") ?: "/tmp"
+    System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local $tmp_dir on the execution node of the Nextflow head process.\n")
+    // TODO: check if images stored there can be accessed by slurm jobs on other nodes
 } else {
     apptainer_tmpdir = new File(apptainer_tmpdir)
     if (! apptainer_tmpdir.exists() ) {

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -10,20 +10,30 @@ workDir = "$scratch_dir/work"
 // Perform work directory cleanup when the run has succesfully completed.
 cleanup = true
 
+// Define function to check if the host machine is the VSC CalcUA.
+// Used to skip various steps in this config during github actions.
+def host_is_calcua() {
+    def host = System.getenv("VSC_INSTITUTE")
+    return ( host == "antwerpen" ) ? true : false
+}
+
 // Check if APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variables are set.
 // If they are available, try to create the tmp directory at the specified location.
-def apptainer_tmpdir = System.getenv("APPTAINER_TMPDIR") ?: System.getenv("SINGULARITY_TMPDIR") ?: null
-if (! apptainer_tmpdir ) {
-    def tmp_dir = System.getenv("TMPDIR") ?: "/tmp"
-    System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local $tmp_dir on the execution node of the Nextflow head process.\n")
-    // TODO: check if images stored there can be accessed by slurm jobs on other nodes
-} else {
-    apptainer_tmpdir = new File(apptainer_tmpdir)
-    if (! apptainer_tmpdir.exists() ) {
-        dir_created = apptainer_tmpdir.mkdirs()
-        if (! dir_created ) {
-            System.err.println("\nWARNING: Could not create directory at the location specified by APPTAINER_TMPDIR/SINGULARITY_TMPDIR: $apptainer_tmpdir\nPlease check if this is a valid path to which you have write permission. Exiting...\n")
-            System.exit(1)
+// Skip if host is not CalcUA to avoid hindering github actions.
+if ( host_is_calcua() ) {
+    def apptainer_tmpdir = System.getenv("APPTAINER_TMPDIR") ?: System.getenv("SINGULARITY_TMPDIR") ?: null
+    if (! apptainer_tmpdir ) {
+        def tmp_dir = System.getenv("TMPDIR") ?: "/tmp"
+        System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local $tmp_dir on the execution node of the Nextflow head process.\n")
+        // TODO: check if images stored there can be accessed by slurm jobs on other nodes
+    } else {
+        apptainer_tmpdir = new File(apptainer_tmpdir)
+        if (! apptainer_tmpdir.exists() ) {
+            dir_created = apptainer_tmpdir.mkdirs()
+            if (! dir_created ) {
+                System.err.println("\nWARNING: Could not create directory at the location specified by APPTAINER_TMPDIR/SINGULARITY_TMPDIR: $apptainer_tmpdir\nPlease check if this is a valid path to which you have write permission. Exiting...\n")
+                System.exit(1)
+            }
         }
     }
 }
@@ -34,6 +44,11 @@ if (! apptainer_tmpdir ) {
 // warn the user.
 // Only applies to the `*_single` profile types.
 def partition_checker(String profile) {
+    // Skip check if host machine is not CalcUA, in order to not hinder github actions.
+    if (! host_is_calcua() ) {
+        // System.err.println("\nWARNING: Skipping comparison of current partition and requested profile because the current machine is not VSC CalcUA.")
+        return
+    }
     def current_partition = System.getenv("SLURM_JOB_PARTITION")
     if (! current_partition) {
         System.err.println("\nWARNING: Current partition could not be found in the expected \$SLURM_JOB_PARTITION environment variable. Please make sure that you submit your pipeline via a Slurm job instead of running the nextflow command directly on a login node.\nExiting...\n")

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -112,14 +112,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'slurm'
             queue = 'zen2'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
     }
     zen2_local {
@@ -129,13 +129,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(64)
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
         partition_checker("zen2")
     }
@@ -146,14 +146,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'slurm'
             queue = 'zen3'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
     }
     zen3_local {
@@ -163,13 +163,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(64)
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
         partition_checker("zen3")
     }
@@ -180,14 +180,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
             max_cpus = 64
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'slurm'
             queue = 'zen3_512'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
     }
     zen3_512_local {
@@ -197,13 +197,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
             max_memory = get_allocated_mem(496) // 512 GB (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(64)
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
         partition_checker("zen3_512")
     }
@@ -215,14 +215,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'slurm'
             queue = 'broadwell'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
     }
     broadwell_local {
@@ -232,13 +232,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = get_allocated_mem(112) // 128 GB (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(28)
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
         partition_checker("broadwell")
     }
@@ -249,14 +249,14 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = 240.GB // 256 (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = 3.days
+            max_time = 3.day
         }
         process {
             executor = 'slurm'
             queue = 'broadwell_256'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
     }
     broadwell_256_local {
@@ -266,13 +266,13 @@ profiles {
             config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
             max_memory = get_allocated_mem(240) // 256 (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(28)
-            max_time = 3.d
+            max_time = 3.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 3.days
+            exitReadTimeout = 3.day
         }
         partition_checker("broadwell_256")
     }
@@ -284,14 +284,14 @@ profiles {
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
             max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
             max_cpus = 28
-            max_time = 7.days
+            max_time = 7.day
         }
         process {
             executor = 'slurm'
             queue = 'skylake'
         }
         executor {
-            exitReadTimeout = 7.days
+            exitReadTimeout = 7.day
         }
     }
     skylake_local {
@@ -301,13 +301,13 @@ profiles {
             config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
             max_memory = get_allocated_mem(176) // 192 GB (total) - 16 GB (buffer)
             max_cpus = get_allocated_cpus(28)
-            max_time = 7.days
+            max_time = 7.day
         }
         process {
             executor = 'local'
         }
         executor {
-            exitReadTimeout = 7.days
+            exitReadTimeout = 7.day
         }
         partition_checker("skylake")
     }
@@ -336,5 +336,5 @@ def get_allocated_mem(int node_max_mem) {
         node_max_mem = mem_per_cpu.toInteger() / 1000 * cpus_per_task.toInteger()
     }
 
-    return "${node_max_mem}.GB" as nextflow.util.MemoryUnit
+    return "${node_max_mem}.GB"
 }

--- a/docs/vsc_calcua.md
+++ b/docs/vsc_calcua.md
@@ -1,3 +1,255 @@
 # nf-core/configs: CalcUA - UAntwerp Tier-2 High Performance Computing Infrastructure (VSC)
 
-> **NB:** You will need an [account](https://docs.vscentrum.be/access/vsc_account.html) to use the HPC cluster to run the pipeline.
+> **NB:** You will need an [account](https://docs.vscentrum.be/access/vsc_account.html) to use the CalcUA VSC HPC cluster to run the pipeline.
+
+<!-- @import "[TOC]" {cmd="toc" depthFrom=2 depthTo=6 orderedList=false} -->
+
+<!-- code_chunk_output -->
+
+- [Quickstart](#quickstart)
+  - [Slurm-scheduled pipeline](#slurm-scheduled-pipeline)
+  - [Running pipeline in a single Slurm job](#running-pipeline-in-a-single-slurm-job)
+- [Step-by-step instructions](#step-by-step-instructions)
+- [Location of output and work directory](#location-of-output-and-work-directory)
+  - [Debug mode](#debug-mode)
+- [Availability of Nextflow](#availability-of-nextflow)
+- [Overview of partition profiles and resources](#overview-of-partition-profiles-and-resources)
+- [Schedule Nextflow pipeline using Slurm](#schedule-nextflow-pipeline-using-slurm)
+- [Local Nextflow run on a single (interactive) node](#local-nextflow-run-on-a-single-interactive-node)
+- [Apptainer / Singularity environment variables for cache and tmp directories](#apptainer--singularity-environment-variables-for-cache-and-tmp-directories)
+- [Troubleshooting](#troubleshooting)
+  - [Failed to pull singularity image](#failed-to-pull-singularity-image)
+
+<!-- /code_chunk_output -->
+
+## Quickstart
+
+To get started with running nf-core pipelines on CalcUA, you can use one of the example templates below. For more detailed info, see the extended explanations further below.
+
+### Slurm-scheduled pipeline
+
+Example `job_script.slurm` to run the pipeline using the Slurm job scheduler to queue the individual tasks making up the pipeline. Note that the head nextflow process used to launch the pipeline does not need to request many resources.
+
+```bash
+#!/bin/bash -l
+#SBATCH --partition=broadwell          # choose partition to run the nextflow head process on
+#SBATCH --job-name=nextflow            # create a short name for your job
+#SBATCH --nodes=1                      # node count
+#SBATCH --cpus-per-task=1              # only 1 cpu cores is needed to run the nextflow head process
+#SBATCH --mem-per-cpu=4G               # memory per cpu (4G is default for most partitions)
+#SBATCH --time=00:02:00                # total run time limit (HH:MM:SS)
+#SBATCH --account=<project-account>    # set project account
+
+# Load the available Nextflow module.
+module load Nextflow
+
+# Or, if using a locally installed version of Nextflow, make Java available.
+# module load Java
+
+# Set Apptainer/Singularity environment variables to define caching and tmp
+# directories. These are used during the conversion of Docker images to
+# Apptainer/Singularity ones.
+# These lines can be omitted if the variables are already set in your `~/.bashrc` file.
+export APPTAINER_CACHEDIR="${VSC_SCRATCH}/apptainer/cache"
+export APPTAINER_TMPDIR="${VSC_SCRATCH}/apptainer/tmp"
+
+# Launch Nextflow head process.
+# Provide a partition profile name to choose a particular partition queue, which
+# will determine the available resources for each individual task in the pipeline.
+# Note that the profile name ends with a `*_slurm` suffix, which indicates
+# that this pipeline will submit each task to the Slurm job scheduler.
+nextflow run nf-core/rnaseq \
+   -profile test,vsc_calcua,broadwell_slurm \
+   -with-report report.html \
+   --outdir test_output
+```
+
+### Running pipeline in a single Slurm job
+
+Example `job_script.slurm` to run the pipeline on a single node in local execution mode, only making use of the resources allocated by `sbatch`.
+
+```bash
+#!/bin/bash -l
+#SBATCH --partition=broadwell          # choose partition to run the nextflow head process on
+#SBATCH --job-name=nextflow            # create a short name for your job
+#SBATCH --nodes=1                      # node count
+#SBATCH --cpus-per-task=28             # request a full node for local execution (broadwell nodes have 28 cpus)
+#SBATCH --mem=112G                     # total memory (e.g., 112G max for broadwell) - can be omitted to use default (= max / # cores)
+#SBATCH --time=00:02:00                # total run time limit (HH:MM:SS)
+#SBATCH --account=<project-account>    # set project account
+
+# Load the available Nextflow module.
+module load Nextflow
+
+# Or, if using a locally installed version of Nextflow, make Java available.
+# module load Java
+
+# Set Apptainer/Singularity environment variables to define caching and tmp
+# directories. These are used during the conversion of Docker images to
+# Apptainer/Singularity ones.
+# These lines can be omitted if the variables are already set in your `~/.bashrc` file.
+export APPTAINER_CACHEDIR="${VSC_SCRATCH}/apptainer/cache"
+export APPTAINER_TMPDIR="${VSC_SCRATCH}/apptainer/tmp"
+
+# Launch Nextflow head process.
+# Provide a partition profile name to choose a particular partition queue, which
+# will determine the available resources for each individual task in the pipeline.
+# Note that the profile name ends with a `*_local` suffix, which indicates
+# that this pipeline will run in local execution mode on the submitted node.
+nextflow run nf-core/rnaseq \
+   -profile test,vsc_calcua,broadwell_local \
+   -with-report report.html \
+   --outdir test_output
+```
+
+## Step-by-step instructions
+
+1. Set the `APPTAINER_CACHEDIR` and `APPTAINER_TMPDIR` environment variables by adding the following lines to your `.bashrc` file (or simply add them to your Slurm job script):
+
+   ```
+   export APPTAINER_CACHEDIR="${VSC_SCRATCH}/apptainer/cache"
+   export APPTAINER_TMPDIR="${VSC_SCRATCH}/apptainer/tmp"
+   ```
+
+   When using the `~/.bashrc` method, you can ensure that the environment variables are available in your jobs by starting your scripts with the line `#! /bin/bash -l`, although this does not seem to be required (see [below](#apptainer--singularity-environment-variables-for-cache-and-tmp-directories) for more info).
+
+2. Load Nextflow in your job script via the command: `module load Nextflow/23.04.2`. Alternatively, when using [your own version of Nextflow](#availability-of-nextflow), use `module load Java`.
+
+3. Choose whether you want to run in [local execution mode on a single node](#local-nextflow-run-on-a-single-interactive-node) or make use of the [Slurm job scheduler to queue individual pipeline tasks](#schedule-nextflow-pipeline-using-slurm).
+
+   - For Slurm scheduling, choose a partition profile ending in `*_slurm`. E.g., `nextflow run pipeline -profile vsc_calcua,broadwell_slurm`.
+   - For local execution mode on a single node, choose a partition profile ending in `*_local`. E.g., `nextflow run pipeline -profile vsc_calcua,broadwell_local`.
+
+   Note that the `-profile` option can take multiple values, the first one always being `vsc_calcua` and the second one a partition plus execution mode.
+
+4. Specify the _partition_ that you want to run the pipeline on using the [`sbatch` command's `--partition=<name>` option](https://docs.vscentrum.be/jobs/job_submission.html#specifying-a-partition) and how many _resources_ should be allocated. See the [overview of partitions and their resources](#overview-of-partition-profiles-and-resources) below, or refer to [the CalcUA documentation](https://docs.vscentrum.be/antwerp/tier2_hardware.html) for more info.
+
+   - For Slurm scheduling, the partition on which the head process runs has no effect on the resources allocated to the actual pipeline tasks. The head process only requires minimal resources (e.g., 1 CPU and 4 GB RAM).
+   - For local execution mode on a single node, the partition selected via `sbatch` must match the one selected with nextflow's `-profile` option, otherwise the pipeline will not launch. It is probably convenient to simply request a full node (e.g., `--cpus-per-task=28` and `--mem=112G` for broadwell). Omitting `--mem-per-cpu` or `--mem` will [allocate the default memory value](https://docs.vscentrum.be/jobs/job_submission.html#requesting-memory), which is the total available memory divided by the number of cores, e.g., `28 * 4 GB = 112 GB` for broadwell (`128 GB - 16 GB buffer`).
+
+5. Submit the job script containing your full `nextflow run` command via `sbatch` or from an an interactive `srun` session launched via `screen` or `tmux` (to avoid the process from stopping when you disconnect your SSH session).
+
+---
+
+## Location of output and work directory
+
+All of the intermediate files required to run the pipeline will be stored in the `work` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
+
+This config contains a `cleanup` command that removes the `work` directory automatically once the pipeline has completed successfully. If the run does not complete successfully then the `work` directory should be removed manually to save storage space. The default work directory is set to `$VSC_SCRATCH/work` per this configuration.
+
+> **NB:** The Nextflow `work` directory for any pipeline is located in `$VSC_SCRATCH` by default.
+
+### Debug mode
+
+Debug mode can be enabled to always retain the `work` directory instead of cleaning it. To use it, pass `debug` as an additional value to the `-profile` option:
+
+`nextflow run <pipeline> -profile vsc_calcua,broadwell_local,debug`
+
+## Availability of Nextflow
+
+Nextflow has been made available on CalcUA as a module. You can find out which versions are available by using `module av nextflow`.
+
+If you need to use a specific version of Nextflow that is not available, you can of course manually install it to your home directory and add the executable to your `PATH`:
+
+```
+curl -s https://get.nextflow.io | bash
+mkdir -p ~/.local/bin/ && mv nextflow ~/.local/bin/
+```
+
+Before it can be used, you will still need to load the Java module in your job scripts: `module load Java`.
+
+## Overview of partition profiles and resources
+
+The CalcUA config defines two types of profiles for each of the following partitions:
+
+| Partition     | Cluster                   | Profile name        | Type                 | Max memory               | Max CPU              | Max wall time | Example usage                                                     |
+| ------------- | ------------------------- | ------------------- | -------------------- | ------------------------ | -------------------- | ------------- | ----------------------------------------------------------------- |
+| zen2          | Vaughan                   | zen2_slurm          | Slurm scheduler      | 240 GB (per task)        | 64 (per task)        | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen2_slurm`          |
+| zen2          | Vaughan                   | zen2_local          | Local node execution | 240 GB (or as requested) | 64 (or as requested) | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen2_local`          |
+| zen3          | Vaughan                   | zen3_slurm          | Slurm scheduler      | 240 GB (per task)        | 64 (per task)        | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen3_slurm`          |
+| zen3          | Vaughan                   | zen3_local          | Local node execution | 240 GB (or as requested) | 64 (or as requested) | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen3_local`          |
+| zen3_512      | Vaughan                   | zen3_512_slurm      | Slurm scheduler      | 496 GB (per task)        | 64 (per task)        | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen3_512_slurm`      |
+| zen3_512      | Vaughan                   | zen3_512_local      | Local node execution | 496 GB (or as requested) | 64 (or as requested) | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,zen3_512_local`      |
+| broadwell     | Leibniz                   | broadwell_slurm     | Slurm scheduler      | 112 GB (per task)        | 28 (per task)        | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,broadwell_slurm`     |
+| broadwell     | Leibniz                   | broadwell_local     | Local node execution | 112 GB (or as requested) | 28 (or as requested) | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,broadwell_local`     |
+| broadwell_256 | Leibniz                   | broadwell_256_slurm | Slurm scheduler      | 240 GB (per task)        | 28 (per task)        | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,broadwell_256_slurm` |
+| broadwell_256 | Leibniz                   | broadwell_256_local | Local node execution | 240 GB (or as requested) | 28 (or as requested) | 3 days        | `nextflow run <pipeline> -profile vsc_calcua,broadwell_256_local` |
+| skylake       | Breniac (formerly Hopper) | skylake_slurm       | Slurm scheduler      | 176 GB (per task)        | 28 (per task)        | 7 days        | `nextflow run <pipeline> -profile vsc_calcua,skylake_slurm`       |
+| skylake       | Breniac (formerly Hopper) | skylake_local       | Local node execution | 240 GB (or as requested) | 28 (or as requested) | 7 days        | `nextflow run <pipeline> -profile vsc_calcua,skylake_local`       |
+
+For more information on the difference between the [\*\_slurm-type](#schedule-nextflow-pipeline-using-slurm) and [\*\_local-type](#local-nextflow-run-on-a-single-interactive-node) profiles, see below. Briefly,
+
+- Slurm profiles submit each pipeline task to the Slurm job scheduler.
+- Local profiles run pipeline tasks on the local node, using only the resource that were requested by `sbatch` (or `srun` in interactive mode).
+
+The max memory for the Slurm partitions is set to the [available amount of memory for each partition](https://docs.vscentrum.be/antwerp/tier2_hardware.html) minus 16 GB (which is the amount reserved for the OS and file system buffers, [see slide 63 of this CalcUA introduction course](https://calcua.uantwerpen.be/courses/hpc-intro/IntroductionHPC-20240226.pdf)). For the local profiles the resources are set dynamically based on those requested by `sbatch`.
+
+More information on the hardware differences between the partitions can be found on [the CalcUA website](https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/) and in the [VSC documentation](https://docs.vscentrum.be/antwerp/tier2_hardware.html). You can also use the `sinfo  -o "%12P %.10A %.11l %D %c %m"` command to see the available partitions yourself.
+
+> **NB:** Do not launch nextflow jobs directly from a login node. Not only will this occupy considerable resources on the login nodes (the nextflow master process/head job can still use considerable amounts of RAM, see [https://nextflow.io/blog/2024/optimizing-nextflow-for-hpc-and-cloud-at-scale.html](https://nextflow.io/blog/2024/optimizing-nextflow-for-hpc-and-cloud-at-scale.html)), but the command might get cancelled (since there is a wall time for the login nodes too).
+
+## Schedule Nextflow pipeline using Slurm
+
+The Slurm profiles allow Nextflow to use the Slurm job scheduler to queue each pipeline task as a separate job. The main job that you manually submit using `sbatch` will run the head Nextflow process (`nextflow run ...`), which acts as a governor and monitoring job, and spawn new Slurm jobs for the different tasks in the pipeline. Each task will request the appropriate amount of resources defined by the pipeline (up to a threshold set in the given partition's profile) and will be run as an individual Slurm job. This means that each task will be placed in the scheduling queue individually and [all the standard priority rules](https://docs.vscentrum.be/jobs/why_doesn_t_my_job_start.html#why-doesn-t-my-job-start) will apply to each of them.
+
+The `nextflow run ...` command that launches the head process, can be invoked either via `sbatch` or from an an interactive `srun` session launched via `screen` or `tmux` (to avoid the process from stopping when you disconnect your SSH session), but it **does NOT need to request the total amount of resources that would be required for the full pipeline!**
+
+> **NB:** When using the slurm-type profiles, the initial job that launches the master nextflow process does not need many resources to run. Therefore, use the #SBATCH options to limit its requested to a small sensible amount (e.g., 2 CPUs and 4 GB RAM), regardless of how computationally intensive the actual pipeline is.
+
+> **NB:** The wall time of the Nextflow head process will ultimately determine how long the pipeline can run for.
+
+## Local Nextflow run on a single (interactive) node
+
+In contrast to the Slurm profiles, the local profiles instead run in Nextflow's _local execution mode_, which means that they do not make use of the Slurm job scheduler. Instead, the head Nextflow process (`nextflow run ...`) will run on the allocated compute node and spawn all of sub-processes for the individual tasks in the pipeline on that same node (i.e., similar to running a pipeline on your own machine). The available resources are determined by the [`#SBATCH` options passed to Slurm](https://docs.vscentrum.be/jobs/job_submission.html#requesting-compute-resources) as usual and are shared among all tasks.
+
+The `nextflow run ...` command that launches the head process, can be invoked either via `sbatch` or from an an interactive `srun` session launched via `screen` or `tmux` (to avoid the process from stopping when you disconnect your SSH session) and it **DOES need to request the total amount of resources that are required by the full pipeline!**
+
+> **NB:** When using one of the single node profiles, make sure that you launch the job on the same partition as the one specified by the `-profile vsc_calcua,<partition>` option of your `nextflow run` command, either by launching it from the matching login node or by using the `sbatch` option `--partition=<partition>`. E.g., a job script containing the following nextflow command:
+> `nextflow run <pipeline> -profile vsc_calcua,broadwell_local`
+> should be launched from a [Leibniz login node](https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html#login-infrastructure) or via the following `sbatch` command:
+> `sbatch --account <project_account> --partition broadwell script.slurm`
+
+> **NB:** The single node profiles **do not** automatically set the pipeline's CPU/RAM resource limits to those of a full node, but instead dynamically set them based on those allocated by Slurm, i.e. those requested via the `sbatch`. However, in many cases, it likely is a good idea to simply request a full node.
+
+## Apptainer / Singularity environment variables for cache and tmp directories
+
+> **NB:** The default directory where Nextflow will cache container images is `$VSC_SCRATCH/apptainer/nextflow_cache`.
+
+> **NB:** The recommended directories for apptainer/singularity's cache and tmp directories are `$VSC_SCRATCH/apptainer/cache` (cache directory for images layers) and `$VSC_SCRATCH/apptainer/tmp` (temporary directory used during build or docker conversion) respectively, to avoid filling up your home storage and/or job node's SSDs (since the default locations when unset are `$HOME/.apptainer/cache` and `/tmp` respectively).
+
+[Apptainer](https://apptainer.org/) is an open-source fork of [Singularity](https://sylabs.io/singularity/), which is an alternative container runtime to Docker. It is more suitable to usage on HPCs because it can be run without root privileges and does not use a dedicated daemon process. More info on the usage of Apptainer/Singularity on the VSC HPC can be found [here](https://docs.vscentrum.be/software/singularity.html).
+
+When executing Nextflow pipelines using Apptainer/Singularity, the container image files will by default be cached inside the pipeline work directory. The CalcUA config profile instead sets the [singularity.cacheDir setting](https://www.nextflow.io/docs/latest/singularity.html#singularity-docker-hub) to a central location on your scratch space (`$VSC_SCRATCH/apptainer/nextflow_cache`), in order to reuse them between different pipelines. This is equivalent to setting the `NXF_APPTAINER_CACHEDIR`/`NXF_SINGULARITY_CACHEDIR` environment variables manually (but note that the `cacheDir` defined in the config file takes precedence and cannot be overwritten by setting the environment variable).
+
+Apptainer/Singularity makes use of two additional environment variables, `APPTAINER_CACHEDIR`/`SINGULARITY_CACHEDIR` and `APPTAINER_TMPDIR`/`SINGULARITY_TMPDIR`. As recommended by the [VSC documentation on containers](https://docs.vscentrum.be/software/singularity.html#building-on-vsc-infrastructure), these should be set to a location on the scratch system, to avoid exceeding the quota on your home directory file system.
+
+> **NB:** The cachedir and tmpdir are only used when new images are built or converted from existing docker images. For most nf-core pipelines this does not happen, since they will instead try to directly pull pre-built singularity images from [Galaxy Depot](https://depot.galaxyproject.org/singularity/)
+
+- The [cache directory](https://apptainer.org/docs/user/main/build_env.html#cache-folders) `APPTAINER_CACHEDIR`/`SINGULARITY_CACHEDIR` is used to store files and layers used during image creation (or conversion of Docker/OCI images). Its default location is `$HOME/.apptainer/cache`, but it is recommended to change this to `$VSC_SCRATCH/apptainer/cache` on the CalcUA HPC instead.
+- The [temporary directory](https://apptainer.org/docs/user/main/build_env.html#temporary-folders) `APPTAINER_TMPDIR`/`SINGULARITY_TMPDIR` is used to store temporary files when building an image (or converting a Docker/OCI source). The directory must have enough free space to hold the entire uncompressed image during all steps of the build process. Its default location is `/tmp`, but it is recommended to change this to `$VSC_SCRATCH/apptainer/tmp` on the CalcUA HPC instead. The reason being that the default `/tmp` would refer to a directory on the the compute node running the master nextflow process, which are [small SSDs on CalcUA](https://docs.vscentrum.be/antwerp/tier2_hardware/uantwerp_storage.html).
+
+  > **NB:** The tmp directory needs to be created manually beforehand, otherwise pipelines that need to pull in and convert docker images, or the manual building of images yourself, will fail.
+
+Currently, Apptainer respects environment variables with either an `APPTAINER` or `SINGULARITY` prefix, but because [support for the latter might be dropped in the future](https://apptainer.org/docs/user/main/singularity_compatibility.html#singularity-prefixed-environment-variable-support), the former variant is recommended.
+
+These two variables can be set in several different ways:
+
+- Specified in your `~/.bashrc` file (e.g., `echo "export APPTAINER_CACHEDIR=${VSC_SCRATCH}/apptainer/cache APPTAINER_TMPDIR=${VSC_SCRATCH}/apptainer/tmp" >> ~/.bashrc`) - recommended.
+- Passed to `sbatch` as a parameter or on a `#SBATCH` line in the job script (e.g., `--export=APPTAINER_CACHEDIR=${VSC_SCRATCH}/apptainer/cache,APPTAINER_TMPDIR=${VSC_SCRATCH}/apptainer/tmp`).
+- Directly in your job script (e.g., `export APPTAINER_CACHEDIR=${VSC_SCRATCH}/apptainer/cache APPTAINER_TMPDIR=${VSC_SCRATCH}/apptainer/tmp`).
+
+However, note that for the `.bashrc` option to work, the environment need to be passed on to the slurm jobs. Currently, this seems to happen by default (i.e., variables defined in `~/.bashrc` are propagated), but there exist methods to enforce this more strictly. E.g., job scripts that start with `#!/bin/bash -l`, will ensure that jobs [launch using your login environment](https://docs.vscentrum.be/leuven/slurm_specifics.html#job-shell). Similarly, the `sbatch` options `[--get-user-env`](https://slurm.schedmd.com/sbatch.html#OPT_get-user-env) or [`--export=`](https://slurm.schedmd.com/sbatch.html#OPT_export) can be used. Also [see the CalcUA-specific](https://docs.vscentrum.be/jobs/slurm_pbs_comparison.html#main-differences-between-slurm-and-torque) and the [general VSC documentation for more info](https://docs.vscentrum.be/jobs/job_submission.html#the-job-environment).
+
+Lastly, note that this config file currently uses the Singularity engine rather than the Apptainer one (see [`singularity` directive: `enabled = true`](https://www.nextflow.io/docs/latest/config.html#scope-singularity)). The reason is that, for the time being, using the apptainer engine in nf-core pipelines will result in docker images being pulled and converted to apptainer ones, rather than making use of pre-built singularity images (see [nf-core documentation](https://nf-co.re/docs/usage/installation#pipeline-software)). Conversely, when making use of the singularity engine, pre-built images are downloaded and Apptainer will still be used in the background for running these, since the installation of `apptainer` will by default create an alias for `singularity` (and this is also the case on CalcUA).
+
+## Troubleshooting
+
+For general errors regarding the pulling of images, try clearing out the existing caches located in `$VSC_SCRATCH/apptainer`.
+
+### Failed to pull singularity image
+
+      FATAL: While making image from oci registry: error fetching image to cache: while building SIF from layers: conveyor failed to get: while getting config: no descriptor found for reference "139610e0c1955f333b61f10e6681e6c70c94357105e2ec6f486659dc61152a21"
+
+Errors similar to the one above can be avoided by first downloading all required container images manually before running the pipeline. It seems like they could be caused by parallel downloads overwhelming the image repository (see [issue](https://github.com/apptainer/singularity/issues/5020)).
+
+To download a pipeline's required images, use `nf-core download <pipeline> --container-system singularity`. See the [nf-core docs](https://nf-co.re/tools#downloading-pipelines-for-offline-use) for more info.

--- a/docs/vsc_calcua.md
+++ b/docs/vsc_calcua.md
@@ -1,0 +1,3 @@
+# nf-core/configs: CalcUA - UAntwerp Tier-2 High Performance Computing Infrastructure (VSC)
+
+> **NB:** You will need an [account](https://docs.vscentrum.be/access/vsc_account.html) to use the HPC cluster to run the pipeline.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -119,6 +119,7 @@ profiles {
     uzh                { includeConfig "${params.custom_config_base}/conf/uzh.config" }
     uzl_omics          { includeConfig "${params.custom_config_base}/conf/uzl_omics.config" }
     vai                { includeConfig "${params.custom_config_base}/conf/vai.config" }
+    vsc_calcua         { includeConfig "${params.custom_config_base}/conf/vsc_calcua.config" }
     vsc_kul_uhasselt   { includeConfig "${params.custom_config_base}/conf/vsc_kul_uhasselt.config" }
     vsc_ugent          { includeConfig "${params.custom_config_base}/conf/vsc_ugent.config" }
     wehi               { includeConfig "${params.custom_config_base}/conf/wehi.config" }


### PR DESCRIPTION
---
name: New Config for VSC CalcUA (UAntwerp)
about: A new cluster config for the VSC CalcUA (UAntwerp)
---

Hi everyone,

Here is a suggested config for the VSC HPC at UAntwerp university. All GitHub actions run successfully and I've debugged and tested almost everything I could think of, both locally and on the HPC. Both local execution mode on a single node and slurm scheduling work, all warnings/restrictions are shown to the user when using undesired combinations of settings, etc. I believe the documentation should be quite helpful to new users too.

The only remaining caveats are:

- The docs state that scopes should not be defined both in the global and in the internal profile. I've added different `executor.exitReadTimeout` directives to each internal profile, but the global profile already had a few other `executor`. Should I duplicate those across all internal profiles too then? Or conversely, if I add the maximum `exitReadTimeout` value to the global config, would this be problematic for the partitions that have a shorter wall time?
- I'm not 100% positive if the dynamic resource allocation for the local execution mode is working as intended. It seems like it from my initial tests though.
- I've omitted the `scratch` directive for now. Options are `process.scratch = true` vs `process.scratch = $VSC_SCRATCH` vs leaving it out entirely.
     - From what I've gathered from the documentation and the nf-core slack, this setting allows you to set the storage location of any files that are created during execution but which are not part of the publishDir, nor of the workDir. I can't really imagine what these are, because I thought that the workDir stored all files which weren't explicitly published. In any case, `true` stores these files in $TMP on the local execution node, whereas $VSC_SCRATCH would be the global user scratch space on our VSC. I believe our HPC team prefers us to not use the local $TMP of the nodes whenever possible.

Lastly, many thanks to everyone who helped me out over Slack during the last couple of days!

---

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [x] Add your custom profile to the `README.md` file in the top-level directory
- [x] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
