### PR TITLE
Patch PDC_KTH profile

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -71,7 +71,7 @@ def clusterOptionsCreator = { mem, time, cpus ->
 
 singularity {
     enabled = true
-    containerOptions = containerOptionsCreator
+    runOptions = containerOptionsCreator
 }
 
 process {


### PR DESCRIPTION
Change `singularity.containerOptions` to `singularity.runOptions` since `containerOptions` is a process directive.