### PR TITLE
Set process medium to use genomics/normal queue

### DIFF
--- a/conf/utd_ganymede.config
+++ b/conf/utd_ganymede.config
@@ -50,6 +50,11 @@ process {
     beforeScript = 'module load singularity/3.2.1'
     executor = 'slurm'
     queue = { select_queue(task.memory, task.cpu) }
+
+    withLabel:process_medium {
+        cpus   = { check_max( 16 * task.attempt, 'cpus' ) }
+        memory = { check_max( 30.GB * task.attempt, 'memory' ) }
+    }
 }
 
 params {


### PR DESCRIPTION
Should use the genomics queue. The 6 cpus and 36GB of memory is just plain off.