### PR TITLE
Add GPU queue to NYGC config

### DIFF
--- a/conf/nygc.config
+++ b/conf/nygc.config
@@ -9,7 +9,7 @@ singularity {
 
 process {
     executor = 'slurm'
-    queue = { task.memory <= 100.GB ? 'pe2' : 'bigmem' }
+    queue = { task.accelerator ? 'gpu' : (task.memory > 100.GB ? 'bigmem' : 'pe2') }}
 }
 
 params {


### PR DESCRIPTION

updates `nygc.config` to use `gpu` queue when a task requests a GPU