### PR TITLE
Add dummy configs for all missing configs

### DIFF
--- a/.github/workflows/update-pipeline-configs.yml
+++ b/.github/workflows/update-pipeline-configs.yml
@@ -1,0 +1,78 @@
+name: Update Pipeline Configs
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run every day at midnight
+  workflow_dispatch:
+
+
+jobs:
+  update_configs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch pipeline names
+        run: |
+          curl -o pipeline_names.json https://nf-co.re/pipeline_names.json
+
+      - name: add test pipeline to pipeline_names.json #TODO remove this testing step after successful tests
+        run: |
+          jq '.pipeline += ["test"]' pipeline_names.json > tmp.json
+          mv tmp.json pipeline_names.json
+
+      - name: Check pipeline names and add missing configs
+        run: |
+            pipeline=$(jq -r '.pipeline[]' pipeline_names.json)
+            for pipeline in $pipeline; do
+              printf "Checking pipeline: %s\n" $pipeline
+              if [ ! -f "pipeline/${pipeline}.config" ]; then
+                cat << EOF > "pipeline/${pipeline}.config"
+            /*
+            * -------------------------------------------------
+            *  nfcore/${pipeline} custom profile Nextflow config file
+            * -------------------------------------------------
+            * Config options for custom environments.
+            * Cluster-specific config options should be saved
+            * in the conf/pipeline/${pipeline} folder and imported
+            * under a profile name here.
+            */
+
+            profiles {
+            }
+            EOF
+              fi
+            done
+
+      - name: inspect test pipeline config #TODO remove this testing step after successful tests
+        run: |
+          cat pipeline/test.config
+
+      - name: clean up
+        run: |
+          rm pipeline_names.json
+
+      - name: Commit & push changes
+        id: commit-and-push
+        run: |
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git add .
+          git status
+          git commit -m "[automated] Update pipeline configs"
+
+        # - name: Create PR
+          # uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6
+          # with:
+          #   token: ${{ secrets.GITHUB_TOKEN }}
+          #   commit-message: Update pipeline configs
+          #   title: Update pipeline configs
+          #   body: |
+          #     This is an automated PR to update pipeline configs for newly created nf-core pipelines.
+          #   branch: 'update-pipeline-configs-'${{ github.run_id }}
+          #   delete-branch: true
+          #   base: 'master'
+          #   draft: false
+
+

--- a/.github/workflows/update-pipeline-configs.yml
+++ b/.github/workflows/update-pipeline-configs.yml
@@ -62,17 +62,17 @@ jobs:
           git status
           git commit -m "[automated] Update pipeline configs"
 
-        # - name: Create PR
-          # uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6
-          # with:
-          #   token: ${{ secrets.GITHUB_TOKEN }}
-          #   commit-message: Update pipeline configs
-          #   title: Update pipeline configs
-          #   body: |
-          #     This is an automated PR to update pipeline configs for newly created nf-core pipelines.
-          #   branch: 'update-pipeline-configs-'${{ github.run_id }}
-          #   delete-branch: true
-          #   base: 'master'
-          #   draft: false
+      - name: Create PR
+        uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update pipeline configs
+          title: Update pipeline configs
+          body: |
+            This is an automated PR to update pipeline configs for newly created nf-core pipelines.
+          branch: 'update-pipeline-configs-'${{ github.run_id }}
+          delete-branch: true
+          base: 'master'
+          draft: false
 
 

--- a/.github/workflows/update-pipeline-configs.yml
+++ b/.github/workflows/update-pipeline-configs.yml
@@ -1,9 +1,8 @@
 name: Update Pipeline Configs
 on:
   schedule:
-    - cron: '0 0 * * *' # Run every day at midnight
+    - cron: "0 0 * * *" # Run every day at midnight
   workflow_dispatch:
-
 
 jobs:
   update_configs:
@@ -24,26 +23,26 @@ jobs:
 
       - name: Check pipeline names and add missing configs
         run: |
-            pipeline=$(jq -r '.pipeline[]' pipeline_names.json)
-            for pipeline in $pipeline; do
-              printf "Checking pipeline: %s\n" $pipeline
-              if [ ! -f "pipeline/${pipeline}.config" ]; then
-                cat << EOF > "pipeline/${pipeline}.config"
-            /*
-            * -------------------------------------------------
-            *  nfcore/${pipeline} custom profile Nextflow config file
-            * -------------------------------------------------
-            * Config options for custom environments.
-            * Cluster-specific config options should be saved
-            * in the conf/pipeline/${pipeline} folder and imported
-            * under a profile name here.
-            */
+          pipeline=$(jq -r '.pipeline[]' pipeline_names.json)
+          for pipeline in $pipeline; do
+            printf "Checking pipeline: %s\n" $pipeline
+            if [ ! -f "pipeline/${pipeline}.config" ]; then
+              cat << EOF > "pipeline/${pipeline}.config"
+          /*
+          * -------------------------------------------------
+          *  nfcore/${pipeline} custom profile Nextflow config file
+          * -------------------------------------------------
+          * Config options for custom environments.
+          * Cluster-specific config options should be saved
+          * in the conf/pipeline/${pipeline} folder and imported
+          * under a profile name here.
+          */
 
-            profiles {
-            }
-            EOF
-              fi
-            done
+          profiles {
+          }
+          EOF
+            fi
+          done
 
       - name: inspect test pipeline config #TODO remove this testing step after successful tests
         run: |
@@ -70,9 +69,7 @@ jobs:
           title: Update pipeline configs
           body: |
             This is an automated PR to update pipeline configs for newly created nf-core pipelines.
-          branch: 'update-pipeline-configs-'${{ github.run_id }}
+            branch: 'update-pipeline-configs-${{ github.run_id }}'
           delete-branch: true
-          base: 'master'
+          base: "master"
           draft: false
-
-

--- a/pipeline/airrflow.config
+++ b/pipeline/airrflow.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/airrflow custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/airrflow folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/bacass.config
+++ b/pipeline/bacass.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/bacass custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/bacass folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/bactmap.config
+++ b/pipeline/bactmap.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/bactmap custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/bactmap folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/bamtofastq.config
+++ b/pipeline/bamtofastq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/bamtofastq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/bamtofastq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/cageseq.config
+++ b/pipeline/cageseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/cageseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/cageseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/callingcards.config
+++ b/pipeline/callingcards.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/callingcards custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/callingcards folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/circdna.config
+++ b/pipeline/circdna.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/circdna custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/circdna folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/circrna.config
+++ b/pipeline/circrna.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/circrna custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/circrna folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/clipseq.config
+++ b/pipeline/clipseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/clipseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/clipseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/coproid.config
+++ b/pipeline/coproid.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/coproid custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/coproid folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/createpanelrefs.config
+++ b/pipeline/createpanelrefs.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/createpanelrefs custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/createpanelrefs folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/createtaxdb.config
+++ b/pipeline/createtaxdb.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/createtaxdb custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/createtaxdb folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/crisprseq.config
+++ b/pipeline/crisprseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/crisprseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/crisprseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/datasync.config
+++ b/pipeline/datasync.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/datasync custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/datasync folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/detaxizer.config
+++ b/pipeline/detaxizer.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/detaxizer custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/detaxizer folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/diaproteomics.config
+++ b/pipeline/diaproteomics.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/diaproteomics custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/diaproteomics folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/differentialabundance.config
+++ b/pipeline/differentialabundance.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/differentialabundance custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/differentialabundance folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/dualrnaseq.config
+++ b/pipeline/dualrnaseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/dualrnaseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/dualrnaseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/epitopeprediction.config
+++ b/pipeline/epitopeprediction.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/epitopeprediction custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/epitopeprediction folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/fastquorum.config
+++ b/pipeline/fastquorum.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/fastquorum custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/fastquorum folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/fetchngs.config
+++ b/pipeline/fetchngs.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/fetchngs custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/fetchngs folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/genomeannotator.config
+++ b/pipeline/genomeannotator.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/genomeannotator custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/genomeannotator folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/genomeassembler.config
+++ b/pipeline/genomeassembler.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/genomeassembler custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/genomeassembler folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/genomeskim.config
+++ b/pipeline/genomeskim.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/genomeskim custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/genomeskim folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/gwas.config
+++ b/pipeline/gwas.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/gwas custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/gwas folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/hgtseq.config
+++ b/pipeline/hgtseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/hgtseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/hgtseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/hic.config
+++ b/pipeline/hic.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/hic custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/hic folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/hicar.config
+++ b/pipeline/hicar.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/hicar custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/hicar folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/hlatyping.config
+++ b/pipeline/hlatyping.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/hlatyping custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/hlatyping folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/imcyto.config
+++ b/pipeline/imcyto.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/imcyto custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/imcyto folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/isoseq.config
+++ b/pipeline/isoseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/isoseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/isoseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/lncpipe.config
+++ b/pipeline/lncpipe.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/lncpipe custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/lncpipe folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/magmap.config
+++ b/pipeline/magmap.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/magmap custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/magmap folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/marsseq.config
+++ b/pipeline/marsseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/marsseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/marsseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/mcmicro.config
+++ b/pipeline/mcmicro.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/mcmicro custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/mcmicro folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/meerpipe.config
+++ b/pipeline/meerpipe.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/meerpipe custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/meerpipe folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/metaboigniter.config
+++ b/pipeline/metaboigniter.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/metaboigniter custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/metaboigniter folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/metapep.config
+++ b/pipeline/metapep.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/metapep custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/metapep folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/metatdenovo.config
+++ b/pipeline/metatdenovo.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/metatdenovo custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/metatdenovo folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/mhcquant.config
+++ b/pipeline/mhcquant.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/mhcquant custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/mhcquant folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/mnaseseq.config
+++ b/pipeline/mnaseseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/mnaseseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/mnaseseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/molkart.config
+++ b/pipeline/molkart.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/molkart custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/molkart folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/multiplesequencealign.config
+++ b/pipeline/multiplesequencealign.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/multiplesequencealign custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/multiplesequencealign folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/nanoseq.config
+++ b/pipeline/nanoseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/nanoseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/nanoseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/nanostring.config
+++ b/pipeline/nanostring.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/nanostring custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/nanostring folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/nascent.config
+++ b/pipeline/nascent.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/nascent custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/nascent folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/omicsgenetraitassociation.config
+++ b/pipeline/omicsgenetraitassociation.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/omicsgenetraitassociation custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/omicsgenetraitassociation folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/oncoanalyser.config
+++ b/pipeline/oncoanalyser.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/oncoanalyser custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/oncoanalyser folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/pangenome.config
+++ b/pipeline/pangenome.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/pangenome custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/pangenome folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/pathogensurveillance.config
+++ b/pipeline/pathogensurveillance.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/pathogensurveillance custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/pathogensurveillance folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/pgdb.config
+++ b/pipeline/pgdb.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/pgdb custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/pgdb folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/phageannotator.config
+++ b/pipeline/phageannotator.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/phageannotator custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/phageannotator folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/phaseimpute.config
+++ b/pipeline/phaseimpute.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/phaseimpute custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/phaseimpute folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/phyloplace.config
+++ b/pipeline/phyloplace.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/phyloplace custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/phyloplace folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/pixelator.config
+++ b/pipeline/pixelator.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/pixelator custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/pixelator folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/proteomicslfq.config
+++ b/pipeline/proteomicslfq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/proteomicslfq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/proteomicslfq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/quantms.config
+++ b/pipeline/quantms.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/quantms custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/quantms folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/radseq.config
+++ b/pipeline/radseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/radseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/radseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/rangeland.config
+++ b/pipeline/rangeland.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/rangeland custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/rangeland folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/readsimulator.config
+++ b/pipeline/readsimulator.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/readsimulator custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/readsimulator folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/reportho.config
+++ b/pipeline/reportho.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/reportho custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/reportho folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/riboseq.config
+++ b/pipeline/riboseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/riboseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/riboseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/rnadnavar.config
+++ b/pipeline/rnadnavar.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/rnadnavar custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/rnadnavar folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/rnasplice.config
+++ b/pipeline/rnasplice.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/rnasplice custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/rnasplice folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/sammyseq.config
+++ b/pipeline/sammyseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/sammyseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/sammyseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/scnanoseq.config
+++ b/pipeline/scnanoseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/scnanoseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/scnanoseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/scrnaseq.config
+++ b/pipeline/scrnaseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/scrnaseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/scrnaseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/seqinspector.config
+++ b/pipeline/seqinspector.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/seqinspector custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/seqinspector folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/slamseq.config
+++ b/pipeline/slamseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/slamseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/slamseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/smrnaseq.config
+++ b/pipeline/smrnaseq.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/smrnaseq custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/smrnaseq folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/spatialvi.config
+++ b/pipeline/spatialvi.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/spatialvi custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/spatialvi folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/spinningjenny.config
+++ b/pipeline/spinningjenny.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/spinningjenny custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/spinningjenny folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/tfactivity.config
+++ b/pipeline/tfactivity.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/tfactivity custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/tfactivity folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/variantbenchmarking.config
+++ b/pipeline/variantbenchmarking.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/variantbenchmarking custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/variantbenchmarking folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/variantcatalogue.config
+++ b/pipeline/variantcatalogue.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/variantcatalogue custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/variantcatalogue folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+

--- a/pipeline/viralintegration.config
+++ b/pipeline/viralintegration.config
@@ -1,0 +1,14 @@
+
+/*
+ * -------------------------------------------------
+ *  nfcore/viralintegration custom profile Nextflow config file
+ * -------------------------------------------------
+ * Config options for custom environments.
+ * Cluster-specific config options should be saved
+ * in the conf/pipeline/viralintegration folder and imported
+ * under a profile name here.
+ */
+
+profiles {
+}
+


### PR DESCRIPTION
This is for allowing us to uncomment out the part in the pipeline template.

I wonder if it just works 'as is' or if we have to add an explicit profile or not... ideas @maxulysse ?