### PR TITLE
update biohpc_gen

### DIFF
--- a/conf/biohpc_gen.config
+++ b/conf/biohpc_gen.config
@@ -5,14 +5,11 @@ params {
     config_profile_url = 'https://collab.dvb.bayern/display/LMUBioHPCGenomics/BioHPC+Genomics'
 }
 
-env {
-    SLURM_CLUSTERS='biohpc_gen'
-}
-
 process {
     executor = 'slurm'
     queue    = { task.memory <= 1536.GB ? (task.time > 2.d || task.memory > 384.GB ? 'biohpc_gen_production' : 'biohpc_gen_normal') : 'biohpc_gen_highmem' }
     module   = 'charliecloud/0.30'
+    clusterOptions = '--clusters=biohpc_gen'
 }
 
 charliecloud {


### PR DESCRIPTION
This config used `env{ SLURM_CLUSTERS='biohpc_gen' }` to specify the correct cluster in the submission. This approach does not work, since this sets `SLURM_CLUSTERS` in `.command.run` after the SBATCH directives. The job is submitted before the variable is set, and as a consequence may target the wrong cluster. `clusterOptions  = '--clusters=biohpc_gen'` solves this by explicitly specifying the cluster to target in the SBATCH directives.
