### PR TITLE
add a default time for arcc config

### DIFF
--- a/conf/arcc.config
+++ b/conf/arcc.config
@@ -8,7 +8,7 @@ params {
     // Default Resources
     max_memory = 64.GB
     max_cpus = 16
-    max_time = 12.h
+    max_time = 1.h
 }
 
 process {

--- a/conf/arcc.config
+++ b/conf/arcc.config
@@ -8,6 +8,7 @@ params {
     // Default Resources
     max_memory = 64.GB
     max_cpus = 16
+    max_time = 12.h
 }
 
 process {
@@ -17,6 +18,7 @@ process {
 
     // Default partitions
     queue = 'beartooth,moran,teton'
+    time = params.max_time
 }
 
 singularity {


### PR DESCRIPTION
---
name: arcc
about: updates ARCC config to include a default time
---

I ran into a few issues when a Nextflow pipeline doesn't provide a default `max_time` value. This update to the config adds a default max_time. 


Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
