### PR TITLE
Call containerOptionsCreator

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -71,7 +71,7 @@ def clusterOptionsCreator = { mem, time, cpus ->
 
 singularity {
     enabled = true
-    runOptions = containerOptionsCreator
+    runOptions = containerOptionsCreator()
 }
 
 process {


### PR DESCRIPTION
Fix to call the containerOptionsCreator rather than assign the closure