### PR TITLE
Dardel java8 fix and apptainer for fuse

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -82,8 +82,3 @@ process {
     clusterOptions = { clusterOptionsCreator(task.memory, task.time, task.cpus) }
 }
 
-env {
-    // Handle java logging on stdout when discovering duplicated cgroups when
-    // running in singularity with Lustre mount
-    JAVA_TOOL_OPTIONS = "-Xlog:disable"
-}

--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -76,7 +76,7 @@ singularity {
 
 process {
     // Should we lock these to specific versions?
-    beforeScript = 'module load PDC singularity'
+    beforeScript = 'module load PDC apptainer'
 
     executor = 'slurm'
     clusterOptions = { clusterOptionsCreator(task.memory, task.time, task.cpus) }


### PR DESCRIPTION
Update PDC/KTH profile for dardel to work around issue with java 8 tooling. Also use apptainer instead of singularity as the apptainer version provided allows for mounting images instead of unpacking.

(We still use `singularity.enabled`  because that works with apptainer and will allow for nextflow to manage image caching better for many pipelines.)