### PR TITLE
Janelia queue size

### DIFF
--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -10,8 +10,8 @@ params {
 
     lsf_opts = ''
     lsf_queue_size = 500
-    schema_ignore_params = 'genomes,lsf_opts'
-    validationSchemaIgnoreParams = "genomes,lsf_opts,schema_ignore_params"
+    schema_ignore_params = 'genomes,lsf_opts,lsf_queue_size'
+    validationSchemaIgnoreParams = "genomes,lsf_opts,lsf_queue_size,schema_ignore_params"
 }
 
 singularity {

--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -9,6 +9,7 @@ params {
     max_time   = '48.h'
 
     lsf_opts = ''
+    lsf_queue_size = 500
     schema_ignore_params = 'genomes,lsf_opts'
     validationSchemaIgnoreParams = "genomes,lsf_opts,schema_ignore_params"
 }
@@ -27,5 +28,6 @@ process {
 executor {
     perTaskReserve = false
     perJobMemLimit = true
+    queueSize = params.lsf_queue_size
 }
 


### PR DESCRIPTION
We'd like to update Janelia's configuration so that there is a default queueSize of 500. We often need to run many Dask workers and the 200 default is not enough. I'm also making this a parameter in case we need to increase it further for special cases.
