### PR TITLE
TWEAK: Add ENA prep profile to nf-core/eager pipeline config for EVA

### DIFF
--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -600,19 +600,19 @@ profiles {
     ena_prep {
         // Profile with minimal processing within nf-core/eager to crate the FastQ/BAM files for ENA upload. This should be used with FASTQ files from Pandora.
         params{
-          // Skip any statistic generation
-          skip_preseq = true
-          skip_damage_calculation = true
-          skip_qualimap = true
-          skip_deduplication = true
-    
-          // Adapter removal
-          skip_collapse = true      // No read collapsing for paired-end data.
-          clip_readlength = 1       // If 0, then empty reads are left in, which breaks downstream processing.
-          clip_min_read_quality = 0 // No base quality filtering.
+            // Skip any statistic generation
+            skip_preseq = true
+            skip_damage_calculation = true
+            skip_qualimap = true
+            skip_deduplication = true
 
-          // Mapping
-          bwaalnn = 0.01
+            // Adapter removal
+            skip_collapse = true      // No read collapsing for paired-end data.
+            clip_readlength = 1       // If 0, then empty reads are left in, which breaks downstream processing.
+            clip_min_read_quality = 0 // No base quality filtering.
+
+            // Mapping
+            bwaalnn = 0.01
         }
     }
 }

--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -597,4 +597,22 @@ profiles {
             bwaalnl = 16500
         }
     }
+    ena_prep {
+        // Profile with minimal processing within nf-core/eager to crate the FastQ/BAM files for ENA upload. This should be used with FASTQ files from Pandora.
+        params{
+          // Skip any statistic generation
+          skip_preseq = true
+          skip_damage_calculation = true
+          skip_qualimap = true
+          skip_deduplication = true
+    
+          // Adapter removal
+          skip_collapse = true      // No read collapsing for paired-end data.
+          clip_readlength = 1       // If 0, then empty reads are left in, which breaks downstream processing.
+          clip_min_read_quality = 0 // No base quality filtering.
+
+          // Mapping
+          bwaalnn = 0.01
+        }
+    }
 }


### PR DESCRIPTION
add ENA prep profile

This profile simply skips any skippable steps, and runs AR without any length/quality filtering and without merging reads.