### PR TITLE
Remove module charliecloud/0.30

### DIFF
--- a/conf/biohpc_gen.config
+++ b/conf/biohpc_gen.config
@@ -8,7 +8,6 @@ params {
 process {
     executor = 'slurm'
     queue    = { task.memory <= 1536.GB ? (task.time > 2.d || task.memory > 384.GB ? 'biohpc_gen_production' : 'biohpc_gen_normal') : 'biohpc_gen_highmem' }
-    module   = 'charliecloud/0.30'
     clusterOptions = '--clusters=biohpc_gen'
 }
 

--- a/docs/biohpc_gen.md
+++ b/docs/biohpc_gen.md
@@ -21,7 +21,7 @@ module load spack
 module load user_spack
 ```
 
-We recommend to use `charliecloud` >= 0.35. 
+We recommend to use `charliecloud` >= 0.35.
 
 ```bash
 spack install charliecloud@0.35

--- a/docs/biohpc_gen.md
+++ b/docs/biohpc_gen.md
@@ -4,12 +4,44 @@ All nf-core pipelines have been successfully configured for use on the BioHPC Ge
 
 To use, run the pipeline with `-profile biohpc_gen`. This will download and launch the [`biohpc_gen.config`](../conf/biohpc_gen.config) which has been pre-configured with a setup suitable for the biohpc_gen cluster. Using this profile, a docker image containing all of the required software will be downloaded, and converted to a Charliecloud container before execution of the pipeline.
 
-Before running the pipeline you will need to load Nextflow and Charliecloud using the environment module system on a login node. You can do this by issuing the commands below:
+> NB: You will need an account to use the LRZ Linux cluster as well as group access to the biohpc_gen cluster in order to run nf-core pipelines.
+
+To correctly submit jobs into the `biohpc_gen` cluster the `SLURM_CLUSTERS` variable needs to be set:
+
+```bash
+export SLURM_CLUSTERS=biohpc_gen
+```
+
+Recent versions can be installed via `spack` and made available as a module.
+
+Cluster specific instructions to load spack:
+
+```bash
+module load spack
+module load user_spack
+```
+
+We recommend to use `charliecloud` >= 0.35. 
+
+```bash
+spack install charliecloud@0.35
+spack module tcl refresh charliecloud
+module avail charliecloud
+```
+
+In addition we recommend using nextflow >= 24.04.2. This can be installed via `spack`:
+
+```bash
+spack install nextflow@24.04.2
+spack module tcl refresh nextflow
+module avail nextflow
+```
+
+These are then available as modules (please confirm the module name using module avail)
 
 ```bash
 ## Load Nextflow and Charliecloud environment modules
-module load nextflow/21.04.3 charliecloud/0.25
+module load nextflow/24.04.2-gcc12 charliecloud/0.35-gcc12
 ```
 
-> NB: You will need an account to use the LRZ Linux cluster as well as group access to the biohpc_gen cluster in order to run nf-core pipelines.
 > NB: Nextflow will need to submit the jobs via the job scheduler to the HPC cluster and as such the commands above will have to be executed on one of the login nodes.


### PR DESCRIPTION
Charliecloud@0.30 is incompatible with the strategy nextflow uses to create temporary containers.

There is no recent version of charliecloud available as a default module, so this cannot be bumped. 
I would remove this and rely on users to load a recent charliecloud version.