### PR TITLE
Use a different env variable to recognize CRG SLURM cluster

### DIFF
--- a/conf/crg.config
+++ b/conf/crg.config
@@ -5,9 +5,9 @@ params {
     config_profile_url = 'http://www.linux.crg.es/index.php/Main_Page'
 }
 
-def host = System.getenv("HOSTNAME")
+def cluster_name = System.getenv("SLURM_CLUSTER_NAME")
 
-if (host ==~ /^genoa64.*/) {
+if (cluster_name == "crg") {
     process {
         executor = 'slurm'
         queue    = 'genoa64'


### PR DESCRIPTION
Fix crg config as the current environmental variable used could have other values different to those use in the config