### PR TITLE
Update vsc_calcua - simplify all the things

### DIFF
--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -59,28 +59,6 @@ if ( System.getenv("VSC_INSTITUTE") == "antwerpen" ) {
     }
 }
 
-// Function to check if the selected partition profile matches the partition on which the head
-// nextflow job was launched (either implicitly or via `sbatch --partition=<partition-name>`).
-// Only used for local execution profiles.
-// If no partition is found (as on the login nodes), warn the user, but do not immediately exit
-// to still allow debugging and testing.
-// If the profile type is `*_local` and the partitions do not match, stop the execution and warn the user.
-def partition_checker(String profile) {
-    // Skip check if host machine is not CalcUA, in order to not hinder github actions.
-    if ( System.getenv("VSC_INSTITUTE") != "antwerpen" ) {
-        return
-    }
-    def current_partition = System.getenv("SLURM_JOB_PARTITION")
-    if (! current_partition) {
-        System.err.println("\nWARNING: Current partition could not be found in the expected \$SLURM_JOB_PARTITION environment variable. Please make sure that you submit your pipeline via a Slurm job or in an interactive `srun` session, instead of running the nextflow command directly on a login node.\n")
-        // TODO: optional exit here, but this makes debugging and testing more difficult.
-    }
-    else if (current_partition != profile) {
-        System.err.println("\nERROR: Slurm job was launched on the \'$current_partition\' partition, but the selected nextflow profile points to the $profile partition instead ('${profile}_local'). When using one of the local node execution profiles, please launch the job on the corresponding partition in Slurm.\nE.g., Slurm job submission command:\n    sbatch --account <project_account> --partition=broadwell script.slurm\nand job script containing a nextflow command with matching profile section:\n    nextflow run <pipeline> -profile vsc_calcua,broadwell_local\nAborting run...\n")
-        System.exit(1)
-    }
-}
-
 // Reduce the job submit rate to about 30 per minute, this way the server
 // won't be bombarded with jobs.
 // Limit queueSize to keep job rate under control and avoid timeouts.
@@ -117,229 +95,120 @@ singularity {
     cacheDir = "$nxf_apptainer_cachedir" // Equivalent to setting NXF_APPTAINER_CACHEDIR/NXF_SINGULARITY_CACHEDIR environment variable
 }
 
+// Shared profile settings
+params {
+    config_profile_contact = "pmoris@itg.be (GitHub: @pmoris)"
+}
+
+// Retrieve name of current partition via Slurm environment variable
+def partition = System.getenv("SLURM_JOB_PARTITION") ?: null
+// Skip check if host is not CalcUA, to avoid hindering github actions.
+if ( System.getenv("VSC_INSTITUTE") == "antwerpen" ) {
+    if(! partition ) {
+        System.err.println("WARNING: Could not retrieve name of current Slurm partition/queue, defaulting to broadwell")
+        partition = "broadwell"
+    }
+}
+
+// Use slurm executor as default, but enable switching to local for single node profile
+def slurm_scheduling = true
+profiles {
+    single_node {
+        slurm_scheduling = false
+    }
+}
+
+// Dynamic partition/queue selection; adapted from https://nf-co.re/configs/vsc_ugent
 // Define profiles for the following partitions:
 // - zen2, zen3, zen3_512 (Vaughan)
 // - broadwell, broadwell_256 (Leibniz)
 // - skylake (Breniac, formerly Hopper)
-// For each partition, there is a "*_slurm" profile and a "*_local" profile.
-// The former uses the slurm executor to submit each nextflow task as a separate job,
-// whereas the latter runs all tasks on the individual node on which the nextflow
-// master process was launched.
-// See: https://www.nextflow.io/docs/latest/config.html#config-profiles
-profiles {
-    // Automatic slurm partition selection based on task requirements
-    slurm {
+switch(partition) {
+    case "zen2":
         params {
-            config_profile_description = 'Slurm profile with automatic partition selection for use on the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware.html'
-            max_memory = 496.GB // = max memory of high memory nodes
-            max_cpus = 64   // = cpu count of largest nodes
-            max_time = 7.day    // wall time of longest running nodes
-        }
-        process {
-            executor = 'slurm'
-            queue = {
-                // long running
-                if ( task.time > 3.day ) {
-                    'skylake'
-                // high memory
-                } else if ( task.memory > 240.GB ) {
-                    'zen3_512'
-                // medium memory and high cpu
-                } else if ( task.memory > 112.GB && task.cpus > 28 ) {
-                    'zen2,zen3'
-                // medium memory and lower cpu
-                } else if ( task.memory > 112.GB && task.cpus < 28 ) {
-                    'broadwell_256,zen2,zen3'
-                // lower memory and high cpu
-                } else if ( task.cpus > 28 ) {
-                    'zen2,zen3'
-                // lower memory and lower cpu
-                } else {
-                    'broadwell,skylake,zen2,zen3'
-                }
-            }
-        }
-    }
-    // Vaughan partitions
-    zen2_slurm {
-        params {
-            config_profile_description = 'Zen2 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            config_profile_description = "Zen2 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
+            max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
         }
         process {
-            executor = 'slurm'
-            queue = 'zen2'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "zen2"
         }
-    }
-    zen2_local {
+        break
+    case "zen3":
         params {
-            config_profile_description = 'Zen2 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(64)
+            config_profile_description = "Zen3 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
+            max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
         }
         process {
-            executor = 'local'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "zen3"
         }
-        partition_checker("zen2")
-    }
-    zen3_slurm {
+        break
+    case "zen3_512":
         params {
-            config_profile_description = 'Zen3 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 240.GB // 256 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            config_profile_description = "Zen3_512 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
+            max_memory = slurm_scheduling ? 496.GB : get_allocated_mem(496) // 512 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
         }
         process {
-            executor = 'slurm'
-            queue = 'zen3'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "zen3_512"
         }
-    }
-    zen3_local {
+        break
+    case "broadwell":
         params {
-            config_profile_description = 'Zen3 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(64)
+            config_profile_description = "Broadwell profile for use on the Leibniz cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html"
+            max_memory = slurm_scheduling ? 112.GB : get_allocated_mem(112) // 128 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 3.day
         }
         process {
-            executor = 'local'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "broadwell"
         }
-        partition_checker("zen3")
-    }
-    zen3_512_slurm {
+        break
+    case "broadwell_256":
         params {
-            config_profile_description = 'Zen3_512 Slurm profile for use on the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = 496.GB // 512 GB (total) - 16 GB (buffer)
-            max_cpus = 64
+            config_profile_description = "Broadwell_256 profile for use on the Leibniz cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html"
+            max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 128 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 3.day
         }
         process {
-            executor = 'slurm'
-            queue = 'zen3_512'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "broadwell_256"
         }
-    }
-    zen3_512_local {
+        break
+    case "skylake":
         params {
-            config_profile_description = 'Zen3_512 local profile for use on a single node of the Vaughan cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html'
-            max_memory = get_allocated_mem(496) // 512 GB (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(64)
-            max_time = 3.day
-        }
-        process {
-            executor = 'local'
-        }
-        partition_checker("zen3_512")
-    }
-    // Leibniz partitions
-    broadwell_slurm {
-        params {
-            config_profile_description = 'Broadwell Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = 112.GB // 128 GB (total) - 16 GB (buffer)
-            max_cpus = 28
-            max_time = 3.day
-        }
-        process {
-            executor = 'slurm'
-            queue = 'broadwell'
-        }
-    }
-    broadwell_local {
-        params {
-            config_profile_description = 'Broadwell local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = get_allocated_mem(112) // 128 GB (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(28)
-            max_time = 3.day
-        }
-        process {
-            executor = 'local'
-        }
-        partition_checker("broadwell")
-    }
-    broadwell_256_slurm {
-        params {
-            config_profile_description = 'Broadwell_256 Slurm profile for use on the Leibniz cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = 240.GB // 256 (total) - 16 GB (buffer)
-            max_cpus = 28
-            max_time = 3.day
-        }
-        process {
-            executor = 'slurm'
-            queue = 'broadwell_256'
-        }
-    }
-    broadwell_256_local {
-        params {
-            config_profile_description = 'Broadwell_256 local profile for use on a single node of the Leibniz cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html'
-            max_memory = get_allocated_mem(240) // 256 (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(28)
-            max_time = 3.day
-        }
-        process {
-            executor = 'local'
-        }
-        partition_checker("broadwell_256")
-    }
-    // Breniac (previously Hopper) partitions
-    skylake_slurm {
-        params {
-            config_profile_description = 'Skylake Slurm profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
-            max_memory = 176.GB // 192 GB (total) - 16 GB (buffer)
-            max_cpus = 28
+            config_profile_description = "Skylake profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC."
+            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/breniac_hardware.html"
+            max_memory = slurm_scheduling ? 176.GB : get_allocated_mem(176) // 192 GB (total) - 16 GB (buffer)
+            max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 7.day
         }
         process {
-            executor = 'slurm'
-            queue = 'skylake'
+            executor = slurm_scheduling ? "slurm" : "local"
+            queue = "skylake"
         }
-    }
-    skylake_local {
-        params {
-            config_profile_description = 'Skylake local profile for use on a single node of the Breniac (former Hopper) cluster of the CalcUA VSC HPC.'
-            config_profile_contact = 'pmoris@itg.be (GitHub: @pmoris)'
-            config_profile_url = 'https://www.uantwerpen.be/en/research-facilities/calcua/infrastructure/'
-            max_memory = get_allocated_mem(176) // 192 GB (total) - 16 GB (buffer)
-            max_cpus = get_allocated_cpus(28)
-            max_time = 7.day
-        }
-        process {
-            executor = 'local'
-        }
-        partition_checker("skylake")
-    }
+        break
 }
 
-    // Define functions to fetch the available CPUs and memory of the current execution node.
-// Only used when running one of the *_local partition profiles and allows the cpu
-// and memory thresholds to be set dynamic based on the available hardware as reported
+// Define functions to fetch the available CPUs and memory of the current execution node.
+// Only used when the single_node / local execution profile is activated.
+// Allows cpu and memory thresholds to be set dynamic based on the available hardware as reported
 // by Slurm. Can be supplied with a default return value, which should be set to the
-// recommended thresholds for the particular partition's node types.
+// recommended thresholds for that particular partition's node types.
 def get_allocated_cpus(int node_max_cpu) {
     max_cpus = System.getenv("SLURM_CPUS_PER_TASK") ?: System.getenv("SLURM_JOB_CPUS_PER_NODE") ?: node_max_cpu
     return max_cpus.toInteger()

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -27,7 +27,7 @@ def nxf_apptainer_cachedir = System.getenv("NXF_APPTAINER_CACHEDIR") ?: System.g
 if ( System.getenv("VSC_INSTITUTE") == "antwerpen" ) {
     // APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable
     if ( !apptainer_tmpdir ) {
-        // Apptainer defaults to $TMPDIR or /tmp (on the SLURM execution node) if this env var is not set.
+        // Apptainer defaults to $TMPDIR or /tmp (on the Slurm execution node) if this env var is not set.
         // See https://apptainer.org/docs/user/main/build_env.html#temporary-folders
         def tmp_dir = System.getenv("TMPDIR") ?: "/tmp"
         System.err.println("\nWARNING: APPTAINER_TMPDIR/SINGULARITY_TMPDIR environment variable was not found.\nPlease add the line 'export APPTAINER_TMPDIR=\"\${VSC_SCRATCH}/apptainer/tmp\"' to your ~/.bashrc file (or set it with sbatch or in your job script).\nDefaulting to local $tmp_dir on the execution node of the Nextflow head process.\n")
@@ -87,7 +87,7 @@ def partition_checker(String profile) {
 // Set read timeout to the maximum wall time.
 // See: https://www.nextflow.io/docs/latest/config.html#scope-executor
 executor {
-    submitRateLimit = '30/1min'
+    submitRateLimit = "30/1min"
     queueSize = 20
     exitReadTimeout = "10 min"
 }
@@ -98,7 +98,7 @@ executor {
 process {
     stageInMode = "symlink"
     stageOutMode = "rsync"
-    errorStrategy = { sleep(Math.pow(2, task.attempt ?: 1) * 200 as long); return 'retry' }
+    errorStrategy = { sleep(Math.pow(2, task.attempt ?: 1) * 200 as long); return "retry" }
     maxRetries = 3
 }
 
@@ -354,7 +354,7 @@ def get_allocated_mem(int node_max_mem) {
     def mem_per_node = System.getenv("SLURM_MEM_PER_NODE")
     def cpus_per_task = System.getenv("SLURM_CPUS_PER_TASK") ?: System.getenv("SLURM_JOB_CPUS_PER_NODE")
 
-    // Check if memory is requested per cpu and the number of cpus was also set
+    // Check if memory was requested per cpu and the number of cpus was also set
     if ( mem_per_cpu && cpus_per_task ) {
         max_mem = mem_per_cpu.toInteger() / 1000 * cpus_per_task.toInteger()
     }

--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -88,8 +88,8 @@ def partition_checker(String profile) {
 // See: https://www.nextflow.io/docs/latest/config.html#scope-executor
 executor {
     submitRateLimit = '30/1min'
-    queueSize = 10
-    exitReadTimeout = 7.day
+    queueSize = 20
+    exitReadTimeout = "10 min"
 }
 
 // Add backoff strategy to catch cluster timeouts and proper symlinks of files in scratch

--- a/docs/vsc_calcua.md
+++ b/docs/vsc_calcua.md
@@ -180,7 +180,7 @@ Before it can be used, you will still need to load the Java module in your job s
 The CalcUA config is built to work with the following partitions:
 
 | Partition     | Cluster                   | Profiles               | Type                        | Max memory               | Max CPU              | Max wall time | Example usage                                   |
-|---------------|---------------------------|------------------------|-----------------------------|--------------------------|----------------------|---------------|-------------------------------------------------|
+| ------------- | ------------------------- | ---------------------- | --------------------------- | ------------------------ | -------------------- | ------------- | ----------------------------------------------- |
 | zen2          | Vaughan                   | vsc_calcua             | Slurm scheduler             | 240 GB (per task)        | 64 (per task)        | 3 days        | `nextflow run  -profile vsc_calcua`             |
 | zen2          | Vaughan                   | vsc_calcua,single_node | Single node local execution | 240 GB (or as requested) | 64 (or as requested) | 3 days        | `nextflow run  -profile vsc_calcua,single_node` |
 | zen3          | Vaughan                   | vsc_calcua             | Slurm scheduler             | 240 GB (per task)        | 64 (per task)        | 3 days        | `nextflow run  -profile vsc_calcua`             |


### PR DESCRIPTION
Based on the feedback in the [previous PR](https://github.com/nf-core/configs/pull/725) (thanks @jfy133 and @nvnieuwk ) and inspired by the config for the UGent VSC, I've tried to simplify the CalcUA config.

See the commit messages for a full breakdown, but briefly:

- Use a sane default profile that uses slurm scheduling.
- Move single node execution mode to a sub-profile.
- Dynamically set the queue and resource limits based on the partition to which the job was submitted.
- Remove dynamic queue selector based on task requirements because it was a pain to debug.
- Increase the queue size and lower the timeout setting.