### PR TITLE
WEHI configuration upgrades

### DIFF
--- a/conf/wehi.config
+++ b/conf/wehi.config
@@ -19,7 +19,7 @@ executor {
 singularity {
     enabled    = true
     autoMounts = true
-    runOptions = '-B /vast -B /stornext -B /wehisan'
+    runOptions = '-B /vast -B /stornext'
 }
 cleanup = true
 profiles {


### PR DESCRIPTION
As of August 2024 /wehisan mounts are no longer present on WEHI HPC compute nodes, and singularity containers run with -profile wehi will fail.

---
name: WEHI
about: Update to WEHI config.
---

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [x] Add your custom profile to the `README.md` file in the top-level directory
- [x] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
