### PR TITLE
roslin.config - Exclude Rocky Linux nodes

### DIFF
--- a/conf/roslin.config
+++ b/conf/roslin.config
@@ -24,9 +24,9 @@ process {
         // Check if an environment variable NFX_SGE_PROJECT exists, if yes, use the stored value for -P option
         // Otherwise set the project to uoe_baseline
         if (System.getenv('NFX_SGE_PROJECT')) {
-            clusterOptions = {"-l h=!node1d01 -l h_vmem=10G -pe sharedmem 5 -P $NFX_SGE_PROJECT"}
+            clusterOptions = {"-l rl9=false -l h=!node1d01 -l h_vmem=10G -pe sharedmem 5 -P $NFX_SGE_PROJECT"}
         } else {
-            clusterOptions = {"-l h=!node1d01 -l h_vmem=10G -pe sharedmem 5 -P uoe_baseline"}
+            clusterOptions = {"-l rl9=false -l h=!node1d01 -l h_vmem=10G -pe sharedmem 5 -P uoe_baseline"}
         }
     }
 
@@ -41,9 +41,9 @@ process {
         // Check if an environment variable NFX_SGE_PROJECT exists, if yes, use the stored value for -P option
         // Otherwise set the project to uoe_baseline
         if (System.getenv('NFX_SGE_PROJECT')) {
-            clusterOptions = {"-l h=!node1d01 -l h_vmem=${(task.memory + 8.GB).bytes/task.cpus} -P $NFX_SGE_PROJECT"}
+            clusterOptions = {"-l rl9=false -l h=!node1d01 -l h_vmem=${(task.memory + 8.GB).bytes/task.cpus} -P $NFX_SGE_PROJECT"}
         } else {
-            clusterOptions = {"-l h=!node1d01 -l h_vmem=${(task.memory + 8.GB).bytes/task.cpus} -P uoe_baseline"}
+            clusterOptions = {"-l rl9=false -l h=!node1d01 -l h_vmem=${(task.memory + 8.GB).bytes/task.cpus} -P uoe_baseline"}
         }
     }
 

--- a/docs/roslin.md
+++ b/docs/roslin.md
@@ -58,6 +58,13 @@ If you wish, you place this variable declaration in your `.bashrc` file located 
 
 **NB:** This will work only with the roslin profile.
 
+## Nodes exclusion
+
+The roslin profile excludes some specific nodes.  
+The superdome node is reserved for special applications, and the access must be requested.
+Eddie's nodes are being migrated to Rocky Linux 9 and some of them are already online. These are not fully set up yet and jobs have troubles to run on them.
+Until those nodes are stable, we exclude them.
+
 ## Running Nextflow
 
 ### On a login node

--- a/docs/roslin.md
+++ b/docs/roslin.md
@@ -60,7 +60,7 @@ If you wish, you place this variable declaration in your `.bashrc` file located 
 
 ## Nodes exclusion
 
-The roslin profile excludes some specific nodes.  
+The roslin profile excludes some specific nodes.
 The superdome node is reserved for special applications, and the access must be requested.
 Eddie's nodes are being migrated to Rocky Linux 9 and some of them are already online. These are not fully set up yet and jobs have troubles to run on them.
 Until those nodes are stable, we exclude them.


### PR DESCRIPTION
A small modification to exclude Rocky Linux 9 nodes that are not fully ready to run nextflow jobs. 