### PR TITLE
add resourceLimits to self_hosted_runner profile

### DIFF
--- a/conf/self_hosted_runner.config
+++ b/conf/self_hosted_runner.config
@@ -8,9 +8,19 @@ params {
 
 
     // General cpus/memory/time requirements
+    // WARNING: This will be deprecated from the pipeline template in favour of resourceLimits
+    // Keeping the parameters for backwards compatibility
     max_cpus = 2
     max_memory = 7.GB
     max_time = 72.h
+}
+
+process {
+    resourceLimits = [
+        cpus: 2,
+        memory: '7.GB',
+        time: '72.h'
+    ]
 }
 
 docker {


### PR DESCRIPTION
Using `resourceLimits` with  self_hosted_runner.
The old parameters are left until the use of `resourceLimits` is implemented in nf-core