### PR TITLE
Update biohpc_gen.config for future nextflow

### DIFF
--- a/conf/biohpc_gen.config
+++ b/conf/biohpc_gen.config
@@ -13,6 +13,7 @@ process {
 
 charliecloud {
     enabled = true
+    writeFake = false
 }
 
 params {


### PR DESCRIPTION
---
name:  Update biohpc_gen.config for future nextflow
about: change charliecloud.writeFake to false
---

The default for `charliecloud.writeFake` will change to `true` in a future nextflow release, `biohpc_gen` is running on an old kernel and does not support `charliecloud.writeFake`.