### PR TITLE
WIP : Updated text plus preference of singularity profile

### DIFF
--- a/conf/ucl_myriad.config
+++ b/conf/ucl_myriad.config
@@ -20,4 +20,5 @@ process {
 singularity {
     enabled      = true
     autoMounts   = true
+    cacheDir     = "${HOME}/Scratch/.apptainer/pull"
 }

--- a/conf/ucl_myriad.config
+++ b/conf/ucl_myriad.config
@@ -1,5 +1,4 @@
 params {
-
     config_profile_description = 'University College London Myriad cluster'
     config_profile_contact     = 'Chris Wyatt (ucbtcdr@ucl.ac.uk)'
     config_profile_url         = 'https://www.rc.ucl.ac.uk/docs/Clusters/Myriad/'
@@ -12,10 +11,13 @@ executor {
 apptainer.runOptions = "-B ${HOME},${PWD}"
 
 process {
-
     //NEED TO SET PARALLEL ENVIRONMENT TO SMP SO MULTIPLE CPUS CAN BE SUBMITTED
     penv           = 'smp'
-
     //PROVIDE EXTRA PARAMETERS AS CLUSTER OPTIONS
     clusterOptions = "-S /bin/bash"
+}
+
+singularity {
+    enabled      = true
+    autoMounts   = true
 }

--- a/docs/ucl_myriad.md
+++ b/docs/ucl_myriad.md
@@ -10,8 +10,9 @@ Before running an nf-core pipeline you will need to set up the requirements and 
 
 You will need the java 11 or later to install and run Nextflow. Different java versions are available in the cluster. To avoid any compatibily issues, use the latest version of `java/temurin`. You can do this by placing the next line inside your `.bashrc`:
 
-```
+```bash
 module load java/temurin-17/17.0.2_8
+
 ```
 
 You can check for other java versions using the `module avail java` command, and load the corresponding version by including `module load java/your-version` inside your `.bashrc`.
@@ -27,24 +28,28 @@ NXF_VER=XX.XX.X
 nextflow -self-update
 chmod a+x nextflow
 mv nextflow ~/bin/nextflow
+
 ```
 
 Then make sure that your bin PATH is executable, by placing the following line in your `.bash_profile`:
 
 ```bash
 export PATH=$PATH:$HOME/bin
+
 ```
 
 ## Running an nf-core pipeline
 
 To run the pipeline, make sure to add `-profile ucl_myriad`. This will download and launch the [`ucl_myriad.config`](../conf/ucl_myriad.config) which has been pre-configured with a setup suitable for the myriad cluster, as well as use the correct container engine for myriad.
 
-```
+```bash
 nextflow run nf-core/your-pipeline -profile ucl_myriad --outdir your/output/directory
-```
-
-You can check your set up is correct by using ``-profile test`` before running the pipeline with your own data.
 
 ```
+
+You can check your set up is correct by using `-profile test` before running the pipeline with your own data.
+
+```bash
 nextflow run nf-core/your-pipeline -profile test,ucl_myriad --outdir your/output/directory
+
 ```

--- a/docs/ucl_myriad.md
+++ b/docs/ucl_myriad.md
@@ -8,13 +8,13 @@ Before running an nf-core pipeline you will need to set up the requirements and 
 
 ### Requirements
 
-You will need the java 11 or later to install and run Nextflow. Different java versions are available in the cluster. To avoid any compatibily issues, use the latest version of ``java/temurin``. You can do this by placing the next line inside your ``.bashrc``:
+You will need the java 11 or later to install and run Nextflow. Different java versions are available in the cluster. To avoid any compatibily issues, use the latest version of `java/temurin`. You can do this by placing the next line inside your `.bashrc`:
 
 ```
 module load java/temurin-17/17.0.2_8
 ```
 
-You can check for other java version using the ``module avail java`` command, and load the correspoding version by including ``module load java/your-version`` inside your ``.bashrc``.
+You can check for other java versions using the `module avail java` command, and load the corresponding version by including `module load java/your-version` inside your `.bashrc`.
 
 ### Install Nextflow
 

--- a/docs/ucl_myriad.md
+++ b/docs/ucl_myriad.md
@@ -4,34 +4,19 @@ All nf-core pipelines have been successfully configured for use on UCL's myriad 
 
 ## Using Nextflow on Myriad
 
-Before running an nf-core pipeline you will need to configure the container engine (Apptainer/Singularity) environmental variables and install Nextflow.
+Before running an nf-core pipeline you will need to set up the requirements and install Nextflow.
 
-### Apptainer/Singularity
+### Requirements
 
-Set the correct configuration of the cache directories. Save the following lines into your `.bash_profile` file in your home directory (e.g. `/home/<YOUR_ID>/.bash_profile`):
+You will need the java 11 or later to install and run Nextflow. Different java versions are available in the cluster. To avoid any compatibily issues, use the latest version of ``java/temurin``. You can do this by placing the next line inside your ``.bashrc``:
 
-```bash
-# Set all the Apptainer environment variables
-export APPTAINER_CACHEDIR=$HOME/Scratch/.apptainer/
-export APPTAINER_TMPDIR=$HOME/Scratch/.apptainer/tmp
-export APPTAINER_LOCALCACHEDIR=$HOME/Scratch/.apptainer/localcache
-export APPTAINER_PULLFOLDER=$HOME/Scratch/.apptainer/pull
+```
+module load java/temurin-17/17.0.2_8
 ```
 
-Plus:
+You can check for other java version using the ``module avail java`` command, and load the correspoding version by including ``module load java/your-version`` inside your ``.bashrc``.
 
-```bash
-
-# Set all Singularity environmental variables
-export SINGULARITY_CACHEDIR=$HOME/Scratch/.singularity/
-export SINGULARITY_TMPDIR=$HOME/Scratch/.singularity/tmp
-export SINGULARITY_LOCALCACHEDIR=$HOME/Scratch/.singularity/localcache
-export SINGULARITY_PULLFOLDER=$HOME/Scratch/.singularity/pull
-export NXF_SINGULARITY_CACHEDIR=$HOME/Scratch/.singularity/
-export SINGULARITY_BINDPATH=/scratch/scratch/$USER,/tmpdir,$SINGULARITY_BINDPATH
-```
-
-### Nextflow
+### Install Nextflow
 
 Download the latest release of nextflow. Warning: the self-update line should update to the latest version, but sometimes not, so please check which is the latest release (https://github.com/nextflow-io/nextflow/releases), you can then manually set this by entering (`NXF_VER=XX.XX.X`).
 
@@ -47,15 +32,19 @@ mv nextflow ~/bin/nextflow
 Then make sure that your bin PATH is executable, by placing the following line in your `.bash_profile`:
 
 ```bash
-export PATH=$PATH:/home/<YOUR_ID>/bin
+export PATH=$PATH:$HOME/bin
 ```
 
 ## Running an nf-core pipeline
 
-To run the pipeline, make sure to add `-profile ucl_myriad,singularity`. This will download and launch the [`ucl_myriad.config`](../conf/ucl_myriad.config) which has been pre-configured with a setup suitable for the myriad cluster, as well as use the correct container engine for myriad.
+To run the pipeline, make sure to add `-profile ucl_myriad`. This will download and launch the [`ucl_myriad.config`](../conf/ucl_myriad.config) which has been pre-configured with a setup suitable for the myriad cluster, as well as use the correct container engine for myriad.
 
-Singularity points to a copy of Apptainer, but you should always tell nextflow to run with `-profile singularity`.
+```
+nextflow run nf-core/your-pipeline -profile ucl_myriad --outdir your/output/directory
+```
 
-```bash
-/usr/bin/singularity -> apptainer
+You can check your set up is correct by using ``-profile test`` before running the pipeline with your own data.
+
+```
+nextflow run nf-core/your-pipeline -profile test,ucl_myriad --outdir your/output/directory
 ```

--- a/docs/ucl_myriad.md
+++ b/docs/ucl_myriad.md
@@ -4,7 +4,7 @@ All nf-core pipelines have been successfully configured for use on UCL's myriad 
 
 ## Using Nextflow on Myriad
 
-Before running an nf-core pipeline you will need to configure the container engine (Apptainer/Singularity) environmental variables and install Nextflow. 
+Before running an nf-core pipeline you will need to configure the container engine (Apptainer/Singularity) environmental variables and install Nextflow.
 
 ### Apptainer/Singularity
 

--- a/docs/ucl_myriad.md
+++ b/docs/ucl_myriad.md
@@ -2,28 +2,34 @@
 
 All nf-core pipelines have been successfully configured for use on UCL's myriad cluster [University College London](https://www.rc.ucl.ac.uk/docs/Clusters/Myriad/).
 
-To use, run the pipeline with `-profile ucl_myriad`. This will download and launch the [`ucl_myriad.config`](../conf/ucl_myriad.config) which has been pre-configured with a setup suitable for the myriad cluster.
-
 ## Using Nextflow on Myriad
 
-Before running the pipeline you will need to configure Apptainer and install+configure Nextflow.
+Before running an nf-core pipeline you will need to configure the container engine (Apptainer/Singularity) environmental variables and install Nextflow. 
 
-### Apptainer
+### Apptainer/Singularity
 
-This can be done with the following commands:
-
-Set the correct configuration of the cache directories, where <YOUR_ID> is replaced with you credentials which you can find by entering `whoami` into the terminal once you are logged into Myriad. Once you have added your credentials save these lines into your `.bash_profile` file in your home directory (e.g. `/home/<YOUR_ID>/.bash_profile`):
+Set the correct configuration of the cache directories. Save the following lines into your `.bash_profile` file in your home directory (e.g. `/home/<YOUR_ID>/.bash_profile`):
 
 ```bash
 # Set all the Apptainer environment variables
-export APPTAINER_CACHEDIR=/home/<YOUR_ID>/Scratch/.apptainer/
-export APPTAINER_TMPDIR=/home/<YOUR_ID>/Scratch/.apptainer/tmp
-export APPTAINER_LOCALCACHEDIR=/home/<YOUR_ID>/Scratch/.apptainer/localcache
-export APPTAINER_PULLFOLDER=/home/<YOUR_ID>/Scratch/.apptainer/pull
+export APPTAINER_CACHEDIR=$HOME/Scratch/.apptainer/
+export APPTAINER_TMPDIR=$HOME/Scratch/.apptainer/tmp
+export APPTAINER_LOCALCACHEDIR=$HOME/Scratch/.apptainer/localcache
+export APPTAINER_PULLFOLDER=$HOME/Scratch/.apptainer/pull
 ```
 
-> [!Warning]
-> You may need to outcomment any singularity environmental variables you have set previously.
+Plus:
+
+```bash
+
+# Set all Singularity environmental variables
+export SINGULARITY_CACHEDIR=$HOME/Scratch/.singularity/
+export SINGULARITY_TMPDIR=$HOME/Scratch/.singularity/tmp
+export SINGULARITY_LOCALCACHEDIR=$HOME/Scratch/.singularity/localcache
+export SINGULARITY_PULLFOLDER=$HOME/Scratch/.singularity/pull
+export NXF_SINGULARITY_CACHEDIR=$HOME/Scratch/.singularity/
+export SINGULARITY_BINDPATH=/scratch/scratch/$USER,/tmpdir,$SINGULARITY_BINDPATH
+```
 
 ### Nextflow
 
@@ -42,4 +48,14 @@ Then make sure that your bin PATH is executable, by placing the following line i
 
 ```bash
 export PATH=$PATH:/home/<YOUR_ID>/bin
+```
+
+## Running an nf-core pipeline
+
+To run the pipeline, make sure to add `-profile ucl_myriad,singularity`. This will download and launch the [`ucl_myriad.config`](../conf/ucl_myriad.config) which has been pre-configured with a setup suitable for the myriad cluster, as well as use the correct container engine for myriad.
+
+Singularity points to a copy of Apptainer, but you should always tell nextflow to run with `-profile singularity`.
+
+```bash
+/usr/bin/singularity -> apptainer
 ```


### PR DESCRIPTION
Update to UCL Myriad config

Made all export env lines universal with $HOME
Requested users use `-profile singularity`, as apptainer does not work for some pipelines. 

@FernandoDuarteF , could you double check with works please. Would be good to quickly check this all works for a couple of pipelines, but should be fine now. Thanks