### PR TITLE
Add project parameter to PDC_KTH profile

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -9,6 +9,8 @@ try {
 }
 
 params {
+    project = null // Naiss project allocation
+
     config_profile_description = 'PDC profile.'
     config_profile_contact = 'Pontus Freyhult (@pontus)'
     config_profile_url = "https://www.pdc.kth.se/"


### PR DESCRIPTION
Adds missing `project` parameter to params section. 