### PR TITLE
Fix vsc_calcua contact details on website

### DIFF
--- a/conf/vsc_calcua.config
+++ b/conf/vsc_calcua.config
@@ -97,7 +97,8 @@ singularity {
 
 // Shared profile settings
 params {
-    config_profile_contact = "pmoris@itg.be (GitHub: @pmoris)"
+    config_profile_contact = "GitHub: @pmoris - Email: pmoris@itg.be"
+    config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware.html"
 }
 
 // Retrieve name of current partition via Slurm environment variable
@@ -127,7 +128,6 @@ switch(partition) {
     case "zen2":
         params {
             config_profile_description = "Zen2 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
             max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
@@ -140,7 +140,6 @@ switch(partition) {
     case "zen3":
         params {
             config_profile_description = "Zen3 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
             max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 256 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
@@ -153,7 +152,6 @@ switch(partition) {
     case "zen3_512":
         params {
             config_profile_description = "Zen3_512 profile for use on the Vaughan cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/vaughan_hardware.html"
             max_memory = slurm_scheduling ? 496.GB : get_allocated_mem(496) // 512 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 64 : get_allocated_cpus(64)
             max_time = 3.day
@@ -166,7 +164,6 @@ switch(partition) {
     case "broadwell":
         params {
             config_profile_description = "Broadwell profile for use on the Leibniz cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html"
             max_memory = slurm_scheduling ? 112.GB : get_allocated_mem(112) // 128 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 3.day
@@ -179,7 +176,6 @@ switch(partition) {
     case "broadwell_256":
         params {
             config_profile_description = "Broadwell_256 profile for use on the Leibniz cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/leibniz_hardware.html"
             max_memory = slurm_scheduling ? 240.GB : get_allocated_mem(240) // 128 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 3.day
@@ -192,7 +188,6 @@ switch(partition) {
     case "skylake":
         params {
             config_profile_description = "Skylake profile for use on the Breniac (former Hopper) cluster of the CalcUA VSC HPC."
-            config_profile_url = "https://docs.vscentrum.be/antwerp/tier2_hardware/breniac_hardware.html"
             max_memory = slurm_scheduling ? 176.GB : get_allocated_mem(176) // 192 GB (total) - 16 GB (buffer)
             max_cpus = slurm_scheduling ? 28 : get_allocated_cpus(28)
             max_time = 7.day


### PR DESCRIPTION
Just a quick update to fix my contact details on the documentation website.

Relevant Slack post I made about this:

> Is the contact section in the docs on the website (the big github logo on the right) taken automatically from the  config_profile_contact  parameter? In my case, it seems to be taken the @domain from my email and using that as a github username. It seems that this is happening for a bunch of other profiles too, since they're pointing to institution or non-existing github pages.
> I think it can be fixed by changing the order of any contact options:     config_profile_contact = "[pmoris@itg.be](mailto:pmoris@itg.be) (GitHub: @pmoris)"  =>     config_profile_contact = "GitHub: @pmoris - Email: [pmoris@itg.be](mailto:pmoris@itg.be)" .

I also fixed the homepage URL while I was at it: I had specified different ones for each partition on our Slurm cluster, but since the doc site was grabbing the first URL it found, I changed this to a single entry for the main homepage.

---

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [x] Add your custom profile to the `README.md` file in the top-level directory
- [x] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
