### PR TITLE
UTD Chores

### DIFF
--- a/conf/utd_ganymede.config
+++ b/conf/utd_ganymede.config
@@ -8,7 +8,6 @@ params {
 }
 
 env {
-    TMPDIR = "/home/$USER/scratch/tmp"
     SINGULARITY_CACHEDIR="/home/$USER/scratch/singularity"
 }
 

--- a/conf/utd_ganymede.config
+++ b/conf/utd_ganymede.config
@@ -22,13 +22,13 @@ singularity {
 def membership = "groups".execute().text
 
 def select_queue = { memory, cpu ->
-    if (memory <= 30.GB && cpu <= 16 && membership.contains('genomics')) {
+    if (memory <= 28.GB && cpu <= 16 && membership.contains('genomics')) {
         return 'genomics,normal'
     }
-    if (memory > 30.GB && memory <= 125.GB && cpu <= 12 && membership.contains('kim')) {
+    if (memory > 28.GB && memory <= 125.GB && cpu <= 12 && membership.contains('kim')) {
         return 'Kim,128s'
     }
-    if (memory > 30.GB && memory <= 125.GB && cpu <= 16) {
+    if (memory > 28.GB && memory <= 125.GB && cpu <= 16) {
         return '128s'
     }
     if (memory <= 250.GB && cpu <= 28) {


### PR DESCRIPTION
- Requests 28.GB of memory(https://community.seqera.io/t/slurm-node-overhead/437?u=emiller)
- Removes setting the tmp directory variable because it upsets MultiQC.