### PR TITLE
Update NYGC and add pe2 profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
           - "pawsey_nimbus"
           - "pawsey_setonix"
           - "pdc_kth"
+          - "pe2"
           - "phoenix"
           - "psmn"
           - "qmul_apocrita"

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Currently documentation is available for the following systems:
 - [PAWSEY NIMBUS](docs/pawsey_nimbus.md)
 - [PAWSEY SETONIX](docs/pawsey_setonix.md)
 - [PDC](docs/pdc_kth.md)
+- [PE2](docs/pe2.md)
 - [PHOENIX](docs/phoenix.md)
 - [PSMN](docs/psmn.md)
 - [QMUL_APOCRITA](docs/qmul_apocrita.md)

--- a/conf/nygc.config
+++ b/conf/nygc.config
@@ -9,7 +9,7 @@ singularity {
 
 process {
     executor = 'slurm'
-    queue    = { task.accelerator ? 'gpu' : (task.memory > 100.GB ? 'bigmem' : 'pe2') }
+    queue    = { task.accelerator ? 'gpu' : 'cpu' }
 }
 
 params {

--- a/conf/pe2.config
+++ b/conf/pe2.config
@@ -1,0 +1,24 @@
+singularityDir = "${HOME}/.singularity/singularity_images_nextflow"
+
+
+singularity {
+    enabled    = true
+    autoMounts = true
+    cacheDir   = singularityDir
+}
+
+process {
+    executor = 'slurm'
+    queue    = { task.accelerator ? 'gpu' : (task.memory > 100.GB ? 'bigmem' : 'pe2') }
+}
+
+params {
+    config_profile_contact     = 'John Zinno (@jzinno)'
+    config_profile_description = 'New York Genome Center (NYGC) cluster profile provided by nf-core/configs.'
+    config_profile_url         = 'https://www.nygenome.org/'
+}
+
+executor {
+    queueSize       = 196
+    submitRateLimit = '5 sec'
+}

--- a/docs/nygc.md
+++ b/docs/nygc.md
@@ -8,8 +8,8 @@ pre-configured with a setup suitable for the New York Genome Center cluster. Usi
 In order to run a pipeline on the NYGC cluster, you will need to load the following modules:
 
 ```bash
-module load singularity/3.8.6
-module load nextflow/22.10.4
+module load singularity
+module load Nextflow
 ```
 
 Note: All of the intermediate files generated from running a pipeline will be stored in the `work/` subdirectory of where the pipeline was launched. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the defined output directory as well.

--- a/docs/pe2.md
+++ b/docs/pe2.md
@@ -1,0 +1,15 @@
+# nf-core/configs: New York Genome Center Configuration
+
+To use, run a pipeline with `-profile pe2`. This will download and launch the [`pe2.config`](../conf/pe2.config) which has been
+pre-configured with a setup suitable for the PE2 cluster (NYGC legacy). Using this profile, container images with all required software will be pulled before execution of a job requiring that software.
+
+## Module Requirements
+
+In order to run a pipeline on the NYGC cluster, you will need to load the following modules:
+
+```bash
+module load singularity/3.8.6
+module load nextflow/22.10.4
+```
+
+Note: All of the intermediate files generated from running a pipeline will be stored in the `work/` subdirectory of where the pipeline was launched. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the defined output directory as well.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -268,6 +268,9 @@ profiles {
     pdc_kth {
         includeConfig "${params.custom_config_base}/conf/pdc_kth.config"
     }
+    pe2 {
+        includeConfig "${params.custom_config_base}/conf/pe2.config"
+    }
     phoenix {
         includeConfig "${params.custom_config_base}/conf/phoenix.config"
     }


### PR DESCRIPTION
Migrates `nygc` config to new cluster and adds support for old cluster under `pe2` profile. The `pe2` profile will be removed when that cluster is phased out. 