### PR TITLE
Batch resourcelimit update pipeline-level institutional configs

### DIFF
--- a/conf/pipeline/eager/eva.config
+++ b/conf/pipeline/eager/eva.config
@@ -618,3 +618,37 @@ profiles {
         }
     }
 }
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+// FOR DSL1 PIPELINE ONLY!
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+                return params.max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+                return params.max_time as nextflow.util.Duration
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min( obj, params.max_cpus as int )
+        } catch (all) {
+            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}

--- a/conf/pipeline/eager/maestro.config
+++ b/conf/pipeline/eager/maestro.config
@@ -113,3 +113,37 @@ profiles {
         }
     }
 }
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+// FOR DSL1 PIPELINE ONLY!
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+                return params.max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+                return params.max_time as nextflow.util.Duration
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min( obj, params.max_cpus as int )
+        } catch (all) {
+            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}

--- a/conf/pipeline/mag/eva.config
+++ b/conf/pipeline/mag/eva.config
@@ -20,30 +20,30 @@ process {
     }
 
     withLabel: process_single {
-        cpus   = { check_max(1, 'cpus') }
-        memory = { check_max(6.GB * task.attempt, 'memory') }
+        cpus   = 1
+        memory = { 6.GB * task.attempt }
         time   = 365.d
     }
     withLabel: process_low {
-        cpus   = { check_max(2 * task.attempt, 'cpus') }
-        memory = { check_max(12.GB * task.attempt, 'memory') }
+        cpus   = { 2 * task.attempt }
+        memory = { 12.GB * task.attempt }
         time   = 365.d
     }
     withLabel: process_medium {
-        cpus   = { check_max(6 * task.attempt, 'cpus') }
-        memory = { check_max(36.GB * task.attempt, 'memory') }
+        cpus   = { 6 * task.attempt }
+        memory = { 36.GB * task.attempt }
         time   = 365.d
     }
     withLabel: process_high {
-        cpus   = { check_max(12 * task.attempt, 'cpus') }
-        memory = { check_max(72.GB * task.attempt, 'memory') }
+        cpus   = { 12 * task.attempt }
+        memory = { 72.GB * task.attempt }
         time   = 365.d
     }
     withLabel: process_long {
         time = 365.d
     }
     withLabel: process_high_memory {
-        memory = { check_max(200.GB * task.attempt, 'memory') }
+        memory = { 200.GB * task.attempt }
         time   = 365.d
     }
     withLabel: error_ignore {
@@ -59,69 +59,69 @@ process {
     }
 
     withName: BOWTIE2_HOST_REMOVAL_BUILD {
-        cpus   = { check_max(10 * task.attempt, 'cpus') }
-        memory = { check_max(20.GB * task.attempt, 'memory') }
+        cpus   = { 10 * task.attempt }
+        memory = { 20.GB * task.attempt }
         time   = 365.d
     }
     withName: BOWTIE2_HOST_REMOVAL_ALIGN {
-        cpus   = { check_max(10 * task.attempt, 'cpus') }
-        memory = { check_max(10.GB * task.attempt, 'memory') }
+        cpus   = { 10 * task.attempt }
+        memory = { 10.GB * task.attempt }
         time   = 365.d
     }
     withName: BOWTIE2_PHIX_REMOVAL_ALIGN {
-        cpus   = { check_max(4 * task.attempt, 'cpus') }
-        memory = { check_max(8.GB * task.attempt, 'memory') }
+        cpus   = { 4 * task.attempt }
+        memory = { 8.GB * task.attempt }
         time   = 365.d
     }
     withName: PORECHOP {
-        cpus   = { check_max(4 * task.attempt, 'cpus') }
-        memory = { check_max(30.GB * task.attempt, 'memory') }
+        cpus   = { 4 * task.attempt }
+        memory = { 30.GB * task.attempt }
         time   = 365.d
     }
     withName: NANOLYSE {
-        cpus   = { check_max(2 * task.attempt, 'cpus') }
-        memory = { check_max(10.GB * task.attempt, 'memory') }
+        cpus   = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
         time   = 365.d
     }
     //filtlong: exponential increase of memory and time with attempts
     withName: FILTLONG {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(64.GB * (2 ** (task.attempt - 1)), 'memory') }
+        cpus   = { 8 * task.attempt }
+        memory = { 64.GB * (2 ** (task.attempt - 1)) }
         time   = 365.d
     }
     withName: CENTRIFUGE {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(40.GB * task.attempt, 'memory') }
+        cpus   = { 8 * task.attempt }
+        memory = { 40.GB * task.attempt }
         time   = 365.d
     }
     withName: KRAKEN2 {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(40.GB * task.attempt, 'memory') }
+        cpus   = { 8 * task.attempt }
+        memory = { 40.GB * task.attempt }
         time   = 365.d
     }
     withName: KRONA {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(20.GB * task.attempt, 'memory') }
+        cpus   = { 8 * task.attempt }
+        memory = { 20.GB * task.attempt }
         time   = 365.d
     }
     withName: CAT_DB_GENERATE {
-        memory = { check_max(200.GB * task.attempt, 'memory') }
+        memory = { 200.GB * task.attempt }
         time   = 365.d
     }
     withName: CAT {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(40.GB * task.attempt, 'memory') }
+        cpus   = { 8 * task.attempt }
+        memory = { 40.GB * task.attempt }
         time   = 365.d
     }
     withName: GTDBTK_CLASSIFYWF {
-        cpus   = { check_max(10 * task.attempt, 'cpus') }
-        memory = { check_max(128.GB * task.attempt, 'memory') }
+        cpus   = { 10 * task.attempt }
+        memory = { 128.GB * task.attempt }
         time   = 365.d
     }
     //MEGAHIT returns exit code 250 when running out of memory
     withName: MEGAHIT {
         cpus          = { check_megahit_cpus(8, task.attempt) }
-        memory        = { check_max(40.GB * task.attempt, 'memory') }
+        memory        = { 40.GB * task.attempt }
         time          = 365.d
         errorStrategy = { task.exitStatus in ((130..145) + 104 + 250) ? 'retry' : 'finish' }
     }
@@ -129,47 +129,47 @@ process {
     //exponential increase of memory and time with attempts, keep number of threads to enable reproducibility
     withName: SPADES {
         cpus          = { check_spades_cpus(10, task.attempt) }
-        memory        = { check_max(64.GB * (2 ** (task.attempt - 1)), 'memory') }
+        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
         time          = 365.d
         errorStrategy = { task.exitStatus in [143, 137, 21, 1] ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     withName: SPADESHYBRID {
         cpus          = { check_spadeshybrid_cpus(10, task.attempt) }
-        memory        = { check_max(64.GB * (2 ** (task.attempt - 1)), 'memory') }
-        time          = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        memory        = { 64.GB * (2 ** (task.attempt - 1)) }
+        time          = { 24.h * (2 ** (task.attempt - 1)), 'time') }
         errorStrategy = { task.exitStatus in [143, 137, 21, 1] ? 'retry' : 'finish' }
         maxRetries    = 5
     }
     //returns exit code 247 when running out of memory
     withName: BOWTIE2_ASSEMBLY_ALIGN {
-        cpus          = { check_max(2 * task.attempt, 'cpus') }
-        memory        = { check_max(8.GB * task.attempt, 'memory') }
-        time          = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        cpus          = { 2 * task.attempt }
+        memory        = { 8.GB * task.attempt }
+        time          = { 24.h * (2 ** (task.attempt - 1)), 'time') }
         errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139, 247] ? 'retry' : 'finish' }
     }
     withName: METABAT2_METABAT2 {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(20.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        cpus   = { 8 * task.attempt }
+        memory = { 20.GB * task.attempt }
+        time   = { 24.h * (2 ** (task.attempt - 1)), 'time') }
     }
     withName: MAG_DEPTHS {
-        memory = { check_max(16.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        memory = { 16.GB * task.attempt }
+        time   = { 24.h * (2 ** (task.attempt - 1)), 'time') }
     }
     withName: BUSCO {
-        cpus   = { check_max(8 * task.attempt, 'cpus') }
-        memory = { check_max(20.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        cpus   = { 8 * task.attempt }
+        memory = { 20.GB * task.attempt }
+        time   = { 24.h * (2 ** (task.attempt - 1)), 'time') }
     }
 
     withName: MAXBIN2 {
         errorStrategy = { task.exitStatus in [1, 255] ? 'ignore' : 'retry' }
-        time          = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        time          = { 24.h * (2 ** (task.attempt - 1)), 'time') }
     }
 
     withName: DASTOOL_DASTOOL {
         errorStrategy = { task.exitStatus in [143, 137, 104, 134, 139] ? 'retry' : task.exitStatus == 1 ? 'ignore' : 'finish' }
-        time          = { check_max(24.h * (2 ** (task.attempt - 1)), 'time') }
+        time          = { 24.h * (2 ** (task.attempt - 1)), 'time') }
     }
 }

--- a/conf/pipeline/rnafusion/hasta.config
+++ b/conf/pipeline/rnafusion/hasta.config
@@ -1,70 +1,70 @@
 process {
     withName: CAT_FASTQ {
-        memory = { check_max(500.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 500.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
-        memory = { check_max(30.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 30.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: SAMPLESHEET_CHECK {
-        memory = { check_max(30.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 30.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: MULTIQC {
-        memory = { check_max(1.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 1.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: SAMTOOLS_VIEW_FOR_ARRIBA {
-        memory = { check_max(6.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 6.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: SAMTOOLS_VIEW_FOR_STARFUSION {
-        memory = { check_max(6.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 6.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: SAMTOOLS_INDEX_FOR_STARFUSION {
-        memory = { check_max(500.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 500.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: SAMTOOLS_INDEX_FOR_ARRIBA {
-        memory = { check_max(500.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 500.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: ARRIBA_VISUALISATION {
-        memory = { check_max(12.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 12.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: ARRIBA {
-        memory = { check_max(36.GB * task.attempt, 'memory') }
-        time   = { check_max(8.h * task.attempt, 'time') }
+        memory = { 36.GB * task.attempt }
+        time   = { 8.h * task.attempt }
         cpus   = 6
     }
     withName: FUSIONREPORT {
-        memory = { check_max(500.MB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 500.MB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: GATK4_MARKDUPLICATES {
-        memory = { check_max(65.GB * task.attempt, 'memory') }
-        time   = { check_max(6.h * task.attempt, 'time') }
+        memory = { 65.GB * task.attempt }
+        time   = { 6.h * task.attempt }
         cpus   = 6
     }
     withName: GATK4_MARKDUPLICATES {
         clusterOptions = { "-A ${params.priority} ${params.clusterOptions ?: ''} ${task.memory ? "--mem ${task.memory.mega * 1.15 as long}M" : ''}" }
     }
     withName: PICARD_COLLECTRNASEQMETRICS {
-        memory   = { check_max(30.GB * task.attempt, 'memory') }
-        time     = { check_max(6.h * task.attempt, 'time') }
+        memory   = { 30.GB * task.attempt }
+        time     = { 6.h * task.attempt }
         cpus     = 2
         ext.args = ' --TMP_DIR . '
     }
@@ -72,8 +72,8 @@ process {
         clusterOptions = { "-A ${params.priority} ${params.clusterOptions ?: ''} ${task.memory ? "--mem ${task.memory.mega * 1.15 as long}M" : ''}" }
     }
     withName: PICARD_COLLECTINSERTSIZEMETRICS {
-        memory   = { check_max(30.GB * task.attempt, 'memory') }
-        time     = { check_max(6.h * task.attempt, 'time') }
+        memory   = { 30.GB * task.attempt }
+        time     = { 6.h * task.attempt }
         cpus     = 2
         ext.args = ' --TMP_DIR . '
     }
@@ -81,58 +81,58 @@ process {
         clusterOptions = { "-A ${params.priority} ${params.clusterOptions ?: ''} ${task.memory ? "--mem ${task.memory.mega * 1.15 as long}M" : ''}" }
     }
     withName: FASTQC_FOR_FASTP {
-        memory = { check_max(4.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 4.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: FASTQC {
-        memory = { check_max(4.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 4.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
     withName: SAMTOOLS_SORT_FOR_ARRIBA {
-        memory = { check_max(8.GB * task.attempt, 'memory') }
-        time   = { check_max(16.h * task.attempt, 'time') }
+        memory = { 8.GB * task.attempt }
+        time   = { 16.h * task.attempt }
         cpus   = 6
     }
     withName: FASTP {
-        memory = { check_max(8.GB * task.attempt, 'memory') }
-        time   = { check_max(16.h * task.attempt, 'time') }
+        memory = { 8.GB * task.attempt }
+        time   = { 16.h * task.attempt }
         cpus   = 6
     }
     withName: FUSIONINSPECTOR {
-        memory = { check_max(40.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * task.attempt, 'time') }
+        memory = { 40.GB * task.attempt }
+        time   = { 24.h * task.attempt }
         cpus   = 12
     }
     withName: FUSIONCATCHER {
-        memory = { check_max(72.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * task.attempt, 'time') }
+        memory = { 72.GB * task.attempt }
+        time   = { 24.h * task.attempt }
         cpus   = 12
     }
     withName: STAR_FOR_STARFUSION {
-        memory = { check_max(50.GB * task.attempt, 'memory') }
-        time   = { check_max(16.h * task.attempt, 'time') }
+        memory = { 50.GB * task.attempt }
+        time   = { 16.h * task.attempt }
         cpus   = 12
     }
     withName: STAR_FOR_ARRIBA {
-        memory = { check_max(40.GB * task.attempt, 'memory') }
-        time   = { check_max(16.h * task.attempt, 'time') }
+        memory = { 40.GB * task.attempt }
+        time   = { 16.h * task.attempt }
         cpus   = 12
     }
     withName: STARFUSION {
-        memory = { check_max(40.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * task.attempt, 'time') }
+        memory = { 40.GB * task.attempt }
+        time   = { 24.h * task.attempt }
         cpus   = 12
     }
     withName: AGAT_CONVERTSPGFF2TSV {
-        memory = { check_max(1.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 1.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 1
     }
     withName: VCF_COLLECT {
-        memory = { check_max(1.GB * task.attempt, 'memory') }
-        time   = { check_max(4.h * task.attempt, 'time') }
+        memory = { 1.GB * task.attempt }
+        time   = { 4.h * task.attempt }
         cpus   = 2
     }
 }

--- a/conf/pipeline/taxprofiler/hasta.config
+++ b/conf/pipeline/taxprofiler/hasta.config
@@ -8,32 +8,32 @@ params {
 process {
 
     withName: BBMAP_BBDUK {
-        memory = { check_max(72.GB * task.attempt, 'memory') }
+        memory = { 72.GB * task.attempt }
     }
 
     withName: KRAKEN2_KRAKEN2 {
-        memory = { check_max(72.GB * task.attempt, 'memory') }
-        time   = { check_max(24.h * task.attempt, 'time') }
+        memory = { 72.GB * task.attempt }
+        time   = { 24.h * task.attempt }
         cpus   = 12
     }
 
     withName: MALT_RUN {
-        memory = { check_max(72.GB * task.attempt, 'memory') }
+        memory = { 72.GB * task.attempt }
     }
 
     withName: MEGAN_RMA2INFO_TSV {
-        memory = { check_max(72.GB * task.attempt, 'memory') }
+        memory = { 72.GB * task.attempt }
     }
 
     withName: DIAMOND_BLASTX {
-        cpus   = { check_max(36 * task.attempt, 'cpus') }
-        memory = { check_max(72.GB * task.attempt, 'memory') }
-        time   = { check_max(72.h * task.attempt, 'time') }
+        cpus   = { 36 * task.attempt }
+        memory = { 72.GB * task.attempt }
+        time   = { 72.h * task.attempt }
     }
 
     withName: KAIJU_KAIJU2TABLE {
-        cpus   = { check_max(6 * task.attempt, 'cpus') }
-        memory = { check_max(36.GB * task.attempt, 'memory') }
-        time   = { check_max(8.h * task.attempt, 'time') }
+        cpus   = { 6 * task.attempt }
+        memory = { 36.GB * task.attempt }
+        time   = { 8.h * task.attempt }
     }
 }


### PR DESCRIPTION
For DSL2 pipelines, we just strip as normal as resourceLimits _should_ be inherited from the main institutional config.

The remaining acrtive DSL1 pipeline (eager) I've copied the check_max function into the file itself, until eager is converted to DSL2

Requires #757 before merging