### PR TITLE
Use machineType for Azure Batch configuration instead of hardcoded VM size

### DIFF
--- a/conf/azurebatch.config
+++ b/conf/azurebatch.config
@@ -14,7 +14,7 @@ params {
     batch_name                 = null
     batch_key                  = null
 
-    vm_type                    = "Standard_D8s_v3"
+    vm_type                    = "Standard_E*d_v5"
     autopoolmode               = true
     allowpoolcreation          = true
     deletejobs                 = true
@@ -33,7 +33,8 @@ process {
 
 azure {
     process {
-        queue = params.az_worker_pool
+        queue       = params.az_worker_pool
+        machineType = params.vm_type
     }
     storage {
         accountName = params.storage_name
@@ -51,7 +52,6 @@ azure {
         deletePoolsOnCompletion = params.deletepools
         pools {
             auto {
-                vmType     = params.vm_type
                 autoScale  = true
                 vmCount    = 1
                 maxVmCount = 12


### PR DESCRIPTION
An idea to use process.machineType instead of a specific VM image. This will mean the autopools feature will be used fully and appropriate sized VM pools will be created for every process.

Also switched to E*d_v5 based on the Azure blog.

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
