### PR TITLE
Fix viralrecon main branch test using nextclade v2

### DIFF
--- a/conf/pipeline/viralrecon/genomes.config
+++ b/conf/pipeline/viralrecon/genomes.config
@@ -15,20 +15,24 @@ params {
             // Please use 'MN908947.3' if possible because all primer sets are available / have been pre-prepared relative to that assembly
             fasta                       = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
             gff                         = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.gff.gz'
-            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2024-10-17--16_48_48Z.tar.gz'
+            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
+            nextclade_dataset_v3pl      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2024-10-17--16_48_48Z.tar.gz'
             nextclade_dataset_name      = 'sars-cov-2'
             nextclade_dataset_reference = 'MN908947'
-            nextclade_dataset_tag       = '2024-10-17--16-48-48Z'
+            nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
+            nextclade_dataset_tag_v3pl  = '2024-10-17--16-48-48Z'
         }
 
         // SARS-CoV-2
         'MN908947.3' {
             fasta                       = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.fna.gz'
             gff                         = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/GCA_009858895.3_ASM985889v3_genomic.200409.gff.gz'
-            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2024-10-17--16_48_48Z.tar.gz'
+            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2022-06-14T12_00_00Z.tar.gz'
+            nextclade_dataset_v3pl      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/MN908947.3/nextclade_sars-cov-2_MN908947_2024-10-17--16_48_48Z.tar.gz'
             nextclade_dataset_name      = 'sars-cov-2'
             nextclade_dataset_reference = 'MN908947'
-            nextclade_dataset_tag       = '2024-10-17--16-48-48Z'
+            nextclade_dataset_tag       = '2022-06-14T12:00:00Z'
+            nextclade_dataset_tag_v3pl  = '2024-10-17--16-48-48Z'
             primer_sets {
                 artic {
                     '1' {
@@ -103,10 +107,12 @@ params {
         'NC_063383.1' {
             fasta                       = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/GCF_014621545.1_ASM1462154v1_genomic.220824.fna.gz'
             gff                         = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/GCF_014621545.1_ASM1462154v1_genomic.220824.gff.gz'
-            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_NC_063383.1_2024-08-27--21-28-04Z.tar.gz'
+            nextclade_dataset           = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_NC_063383.1_2022-08-19T12_00_00Z.tar.gz'
+            nextclade_dataset_v3pl      = 'https://github.com/nf-core/test-datasets/raw/viralrecon/genome/NC_063383.1/nextclade_hMPXV_NC_063383.1_2024-08-27--21-28-04Z.tar.gz'
             nextclade_dataset_name      = 'hMPXV'
             nextclade_dataset_reference = 'NC_063383.1'
-            nextclade_dataset_tag       = '2024-08-27--21-28-04Z'
+            nextclade_dataset_tag       = '2022-08-19T12:00:00Z'
+            nextclade_dataset_tag_v3pl  = '2024-08-27--21-28-04Z'
         }
 
         // Monkeypox


### PR DESCRIPTION
---
name: New Config
about: A new cluster config
---

With #787, nextclade datasets were added that are compatible with v3 but not with v2. While `dev` branch might soon have v3, the `main` branch still has v2, and tests failed.  

New tags were added with the suffix `'_v3pl'` for the datasets that are compatible with nextclade's version 3 and above. 

- [X] Your PR targets the `master` branch
- [X] You've included links to relevant issues, if any

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
