### PR TITLE
Cheaha queue update

### DIFF
--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -26,13 +26,33 @@ process {
         time: 150.h
     ]
     executor = 'slurm'
-    queue = { task.memory <= 50.GB ? (task.time <= 2.h ? 'express' : task.time <= 12.h ? 'short' : task.time <= 50.h ? 'medium' : 'long') : (task.time <= 50.h ? 'largemem' : 'largemem-long')}
     maxRetries = 3
     beforeScript = 'module load Singularity/3.5.2-GCC-5.4.0-2.26'
+    queue = getQueues( task.time, task.memory ) 
 }
 
-params {
-    max_memory = 750.GB
-    max_cpus = 128
-    max_time = 150.h
+def getQueues = { time, memory ->
+    def queue_list = ["long"]
+
+    if (time <= 2.h) {
+        queue_list.add("express")
+    }
+
+    if (time <= 12.h) {
+        queue_list.add("short")
+    }
+
+    if (time <= 50.h) {
+        queue_list.add("medium")
+    }
+
+    if (memory >= 300.GB) {
+        queue_list.add("largemem-long")
+
+        if (time <= 50.h) {
+            queue_list.add("largemem")
+        }
+    }
+
+    return queue_list.join(",")
 }

--- a/conf/cheaha.config
+++ b/conf/cheaha.config
@@ -19,18 +19,6 @@ singularity {
     runOptions = "--contain --workdir $scratch_dir"
 }
 
-process {
-    resourceLimits = [
-        memory: 750.GB,
-        cpus: 128,
-        time: 150.h
-    ]
-    executor = 'slurm'
-    maxRetries = 3
-    beforeScript = 'module load Singularity/3.5.2-GCC-5.4.0-2.26'
-    queue = getQueues( task.time, task.memory ) 
-}
-
 def getQueues = { time, memory ->
     def queue_list = ["long"]
 
@@ -55,4 +43,16 @@ def getQueues = { time, memory ->
     }
 
     return queue_list.join(",")
+}
+
+process {
+    resourceLimits = [
+        memory: 750.GB,
+        cpus: 128,
+        time: 150.h
+    ]
+    executor = 'slurm'
+    maxRetries = 3
+    beforeScript = 'module load Singularity/3.5.2-GCC-5.4.0-2.26'
+    queue = { getQueues( task.time, task.memory ) }
 }


### PR DESCRIPTION
This PR updates the Cheaha config to allow for jobs to be submitted to multiple partitions/queues based on the job requirements. SLURM will automatically send jobs to the first queue that opens up with available resources, which should minimize the amount of time that jobs are pending.