### PR TITLE
VSC_UGENT: fix issue for tier1 clusters

### DIFF
--- a/conf/vsc_ugent.config
+++ b/conf/vsc_ugent.config
@@ -80,7 +80,7 @@ aws {
     maxErrorRetry = 3
 }
 
-def cluster = System.getenv("SLURM_CLUSTERS") ?: System.getenv("HPCUGENT_FAMILY_CLUSTER_VERSION") ?: ""
+def cluster = System.getenv("HPCUGENT_FAMILY_CLUSTER_VERSION") ?: System.getenv("SLURM_CLUSTERS") ?: ""
 
 if( !cluster ) {
     System.err.println("WARNING: Could not get the name of the currently used cluster, defaulting to doduo")


### PR DESCRIPTION
This fixes a small issue when running the config on tier1 clusters where `dodrio` was used as cluster name instead of the specific tier1 partition