### PR TITLE
Reflect changes on what jobs may run on shared partition

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -40,7 +40,7 @@ def clusterOptionsCreator = { mem, time, cpus ->
         case "dardel":
             String extra = ''
 
-            if (time < 7.d && mem <= 222.GB && cpus < 256) {
+            if (time < 7.d && mem <= 111.GB && cpus < 256) {
                 extra += ' -p shared '
             }
             else if (time < 1.d) {


### PR DESCRIPTION
Adapt to changed reality, we must now regard `MaxMemPerCPU` (which regards actual CPUs, not hyperthread units).