### PR TITLE
update daisybio profile: use group of the launch directory for work directory

### DIFF
--- a/conf/daisybio.config
+++ b/conf/daisybio.config
@@ -11,7 +11,17 @@ params {
 // define workDir in /nfs/scratch/nf-core_work/ named after the launch dir
 def work_dir = "/nfs/scratch/nf-core_work/"
 if(new File(work_dir).exists() && System.getenv("PWD")) {
-        workDir = work_dir+System.getenv("PWD").tokenize('/').join('.')
+    work_dir = work_dir+System.getenv("PWD").tokenize('/').join('.')
+    workDir = work_dir
+
+    // if directory does not exist, create it and set the group to the group launch dir
+    if(!new File(work_dir).exists()) {
+        "mkdir -p ${work_dir}".execute()
+        def pwd = System.getenv("PWD")
+        def group = "stat -c %g ${pwd}".execute().text.trim()
+        "chgrp -R ${group} ${work_dir}".execute()
+        "chmod -R g+s ${work_dir}".execute()
+    }
 }
 
 process {


### PR DESCRIPTION
---
name: daisybio profile update
about: use group of the launch directory for work directory
---

Our profile creates all work directories in a centralized location. Currently, this work directory will belong to the group of the user launching the pipeline. As a consequence, only this user will be able to use Nextflow's resume feature.

This update sets the group of the work directory (and group special permission) to the group of the launch directory to allow all users in a shared group project to access the work directory and use the resume feature.

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
