### PR TITLE
bump EVA max mem

### DIFF
--- a/conf/eva.config
+++ b/conf/eva.config
@@ -25,14 +25,14 @@ profiles {
         params {
             igenomes_base              = "/mnt/archgen/public_data/igenomes"
             config_profile_description = 'MPI-EVA archgen profile, provided by nf-core/configs.'
-            max_memory                 = 256.GB
+            max_memory                 = 370.GB
             max_cpus                   = 32
             max_time                   = 365.d
         }
 
         process {
             resourceLimits = [
-                memory: 256.GB,
+                memory: 370.GB,
                 cpus: 32,
                 time: 365.d
             ]


### PR DESCRIPTION
Increase max mem since most nodes have more than 256Gb of memory
