### PR TITLE
Update vsc_kul_uhasselt.conf -- Dynamically adjust account based on queue type

### DIFF
--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -1,9 +1,9 @@
 // Default to /tmp directory if $VSC_SCRATCH scratch env is not available,
 // see: https://github.com/nf-core/configs?tab=readme-ov-file#adding-a-new-config
-scratch_dir         = System.getenv("VSC_SCRATCH") ?: "/tmp"
-tier1_project       = System.getenv("SLURM_ACCOUNT") ?: null
-def avail_queues    = System.getenv("VSC_DEDICATED_QUEUES") ?: ""
-def availQueues     = avail_queues.toString().split(',')
+def SCRATCH_DIR      = System.getenv("VSC_SCRATCH") ?: "/tmp"
+def TIER2_PROJECT    = System.getenv("SLURM_ACCOUNT") ?: null
+def DEDICATED_QUEUES = System.getenv("VSC_DEDICATED_QUEUES") ?: ""
+def AVAILABLE_QUEUES = DEDICATED_QUEUES.toString().split(',')
 
 // Perform work directory cleanup when the run has succesfully completed
 // cleanup = true
@@ -30,7 +30,7 @@ process {
 singularity {
     enabled     = true
     autoMounts  = true
-    cacheDir    = "$scratch_dir/.singularity"
+    cacheDir    = "$SCRATCH_DIR/.singularity"
     pullTimeout = "30 min"
 }
 
@@ -40,8 +40,8 @@ params {
 }
 
 env {
-    APPTAINER_TMPDIR="$scratch_dir/.apptainer/tmp"
-    APPTAINER_CACHEDIR="$scratch_dir/.apptainer/cache"
+    APPTAINER_TMPDIR="$SCRATCH_DIR/.apptainer/tmp"
+    APPTAINER_CACHEDIR="$SCRATCH_DIR/.apptainer/cache"
 }
 
 // AWS maximum retries for errors (This way the pipeline doesn't fail if the download fails one time)
@@ -49,10 +49,131 @@ aws {
     maxErrorRetry = 3
 }
 
-// Function to limit task time when dedicated queues are not available
+/*
+ * Queue Selection Utility Functions for HPC Environments
+ * ==================================================
+ * This module provides functions to determine appropriate HPC queues based on task requirements
+ * for both GENIUS and WICE clusters.
+ */
+
+/*
+ * Constants:
+ * ----------
+ * TIME_THRESHOLD: 72 hours - Threshold for determining long-running jobs
+ * MEMORY_THRESHOLD (GENIUS): 175GB - Memory threshold for bigmem queues
+ * MEMORY_THRESHOLD (WICE): 239GB - Memory threshold for high-memory queues
+*/
+def TIME_THRESHOLD = 72.h
+def MEMORY_THRESHOLD_GENIUS = 175.GB
+def MEMORY_THRESHOLD_WICE = 239.GB
+
+/*
+ * ---------
+ * Functions:
+ * ----------
+ * These functions are designed to select the appropriate HPC queues of
+ * VSC_KUL_UHASSELT based on task requirements. They handle both standard
+ * and GPU queues, considering memory requirements, execution time, and
+ * queue availability.
+*/
+
+/*
+ * limitTaskTime(time, maxTime)
+ *     Ensures task time doesn't exceed the maximum allowed time
+ *     @param time Current task time
+ *     @param maxTime Maximum allowed time
+ *     @return Limited task time
+*/
 def limitTaskTime(time, maxTime) {
     return time > maxTime ? maxTime : time
 }
+
+/*
+ * determineGeniusQueue(task)
+ *     Selects appropriate CPU queue for GENIUS cluster
+ *     @param task Nextflow task object containing memory and time requirements
+ *     @return Queue name based on task requirements
+*/
+def determineGeniusQueue = { task ->
+    if (task.memory >= MEMORY_THRESHOLD_GENIUS) {
+        if (task.time >= TIME_THRESHOLD) {
+            return AVAILABLE_QUEUES.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem_long'
+        }
+        return 'bigmem'
+    }
+    return task.time >= TIME_THRESHOLD ? 'batch_long' : 'batch'
+}
+
+/*
+ * determineGeniusGpuQueue(task)
+ *     Selects appropriate GPU queue for GENIUS cluster
+ *     @param task Nextflow task object containing memory and time requirements
+ *     @return GPU queue name based on task requirements
+*/
+def determineGeniusGpuQueue = { task ->
+    if (task.memory >= MEMORY_THRESHOLD_GENIUS) {
+        return task.time >= TIME_THRESHOLD ? 'gpu_v100_long' : 'gpu_v100'
+    }
+    if (task.time >= TIME_THRESHOLD) {
+        return AVAILABLE_QUEUES.contains('dedicated_rega_gpu') ? 'dedicated_rega_gpu' : 'gpu_p100_long,amd_long'
+    }
+    return 'gpu_p100,amd'
+}
+
+/*
+ * determineWiceQueue(task)
+ *     Selects appropriate CPU queue for WICE cluster
+ *     @param task Nextflow task object containing memory and time requirements
+ *     @return Queue name based on task requirements and availability
+*/
+def determineWiceQueue = { task ->
+    if (task.memory >= MEMORY_THRESHOLD_WICE) {
+        if (AVAILABLE_QUEUES.contains('dedicated_big_bigmem')) {
+            return 'dedicated_big_bigmem'
+        } else {
+            task.time = limitTaskTime(task.time, TIME_THRESHOLD)
+            return 'bigmem,hugemem'
+        }
+    }
+
+    return task.time >= TIME_THRESHOLD ?
+        'batch_long,batch_icelake_long,batch_sapphirerapids_long' :
+        'batch,batch_sapphirerapids,batch_icelake'
+}
+
+/*
+ * determineWiceGpuQueue(task)
+ *     Selects appropriate GPU queue for WICE cluster
+ *     @param task Nextflow task object containing memory and time requirements
+ *     @return GPU queue name based on task requirements
+*/
+def determineWiceGpuQueue = { task ->
+    def isHighMemory = task.memory >= MEMORY_THRESHOLD_WICE
+    def isDedicatedQueue = isHighMemory ?
+        AVAILABLE_QUEUES.contains('dedicated_big_gpu_h100') :
+        AVAILABLE_QUEUES.contains('dedicated_big_gpu')
+
+    if (task.time >= TIME_THRESHOLD && !isDedicatedQueue) {
+        task.time = limitTaskTime(task.time, TIME_THRESHOLD)
+    }
+
+    if (isHighMemory) {
+        return isDedicatedQueue ? 'dedicated_big_gpu_h100' : 'gpu_h100'
+    } else {
+        return isDedicatedQueue ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
+    }
+}
+
+/*
+ * ========
+ * Profiles
+ * ========
+    * These profiles define the resource limits, queue selection, and cluster options
+    * for WICE and GENIUS clusters. They also include GPU-specific configurations.
+    * Details of the resource limits can be found in for genius at
+    * https://docs.vscentrum.be/leuven/tier2_hardware/genius_hardware.html
+    * and for wice at https://docs.vscentrum.be/leuven/tier2_hardware/wice_hardware.html
+*/
 
 // Define profiles for each cluster
 profiles {
@@ -62,31 +183,22 @@ profiles {
         process {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 36, time: 168.h ]
-            beforeScript = 'module load cluster/genius'
-            clusterOptions = { "--clusters=genius --account=$tier1_project" }
-
-            queue = {
-                task.memory >= 175.GB ?
-                    (task.time >= 72.h ? 'dedicated_big_bigmem,dedicated_big_batch,bigmem_long' : 'bigmem') :
-                    (task.time >= 72.h ? 'batch_long' : 'batch')
+            beforeScript   = 'module load cluster/genius'
+            queue          = { determineGeniusQueue(task) }
+            clusterOptions = {
+                determineGeniusQueue(task) =~ /dedicated/ ?
+                    "--clusters=genius --account=lp_big_genius_cpu" :
+                    "--clusters=genius --account=$TIER2_PROJECT"
             }
 
             withLabel: '.*gpu.*'{
                 resourceLimits         = [ memory: 703.GB, cpus: 36 , time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
-
-                // Set clusteroptions
+                queue                  = { determineGeniusGpuQueue(task) }
                 clusterOptions         = {
-                    // suggested to use 9 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/9) as int)
-                    "--gres=gpu:${gpus} --clusters=genius --account=$tier1_project"
-                }
-
-                queue = {
-                    task.memory >= 175.GB ?
-                        (task.time >= 72.h ? 'gpu_v100_long' : 'gpu_v100') :
-                        (task.time >= 72.h ? 'gpu_p100_long,amd_long' : 'gpu_p100,amd')
+                    "--gres=gpu:${gpus} --clusters=genius --account=$TIER2_PROJECT"
                 }
             }
         }
@@ -101,15 +213,10 @@ profiles {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 36, time: 168.h]
             beforeScript   = 'module load cluster/genius'
+            queue         = { determineGeniusGpuQueue(task) }
             clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/9) as int)
-                "--gres=gpu:${gpus} --clusters=genius --account=$tier1_project"
-            }
-
-            queue = {
-                    task.memory >= 175.GB ?
-                        (task.time >= 72.h ? 'gpu_v100_long' : 'gpu_v100') :
-                        (task.time >= 72.h ? 'gpu_p100_long,amd_long' : 'gpu_p100,amd')
+                "--gres=gpu:${gpus} --clusters=genius --account=$TIER2_PROJECT"
             }
         }
     }
@@ -121,66 +228,24 @@ profiles {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-
-            // Set queue
-            // The task time is limites to 72 hours if the memory is larger than 239GB
-            // and dedicated queues are not available
-            queue = {
-                def maxTime = 72.h
-                if (task.memory >= 239.GB) {
-                    task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_bigmem') ?
-                        limitTaskTime(task.time, maxTime) : task.time
-                    return availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem'
-                } else {
-                    return task.time >= maxTime ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake'
-                }
-            }
-
-            // Set clusterOptions, changing account based on queue
+            queue          = { determineWiceQueue(task) }
             clusterOptions = {
-                def queueValue = {
-                    task.memory >= 239.GB ?
-                        (task.time >= 72.h && availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
-                        (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
-                }
-                queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
+                determineWiceQueue(task) =~ /dedicated/ ?
+                    "--clusters=wice --account=lp_big_wice_cpu" :
+                    "--clusters=wice --account=$TIER2_PROJECT"
             }
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
-
-                // Set queue
-                // The task time is limites to 72 hours if the memory is larger than 239GB
-                // and dedicated queues are not available
-                queue = {
-                    def maxTime = 72.h
-                    if (task.memory >= 239.GB) {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ?
-                            limitTaskTime(task.time, maxTime) : task.time
-                        return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
-                    } else {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ?
-                            limitTaskTime(task.time, maxTime) : task.time
-                        return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
-                    }
-                }
-
-                clusterOptions = {
-                    // suggested to use 16 cpus per gpu
+                queue                  = { determineWiceGpuQueue(task) }
+                clusterOptions         = {
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                    // Do same queue evaluation as above
-                    def queueValue = {
-                        task.memory >= 239.GB ?
-                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
-                    }
-
-                    // Set clusterOptions, changing account based on queue
-                    queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
-                    queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
-                    "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+                    def queueValue = determineWiceGpuQueue(task)
+                    queueValue =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
+                    queueValue =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
+                    "--clusters=wice --account=$TIER2_PROJECT --gres=gpu:${gpus}"
                 }
             }
         }
@@ -193,39 +258,15 @@ profiles {
 
         process {
             // 768 - 65 so 65GB for overhead, max is 720000MB
-            resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
-            beforeScript   = 'module load cluster/wice'
-                // Set queue
-                // The task time is limites to 72 hours if the memory is larger than 239GB
-                // and dedicated queues are not available
-            queue = {
-                    def maxTime = 72.h
-                    if (task.memory >= 239.GB) {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ?
-                            limitTaskTime(task.time, maxTime) : task.time
-                        return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
-                    } else {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ?
-                            limitTaskTime(task.time, maxTime) : task.time
-                        return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
-                    }
-            }
-
-            // Set clusteroptions
-            clusterOptions = {
-                // suggested to use 16 cpus per gpu
+            beforeScript           = 'module load cluster/wice'
+            resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
+            queue                  = { determineWiceGpuQueue(task) }
+            clusterOptions         = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                // Do same queue evaluation as above, without adjusting task.time
-                def queueValue = {
-                    task.memory >= 239.GB ?
-                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
-                }
-
-                // Set clusterOptions, changing account based on queue
-                queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
-                queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
-                "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+                def queueValue = determineWiceGpuQueue(task)
+                queueValue =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
+                queueValue =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
+                "--clusters=wice --account=$TIER2_PROJECT --gres=gpu:${gpus}"
             }
         }
     }
@@ -234,7 +275,7 @@ profiles {
         params.config_profile_description = 'superdome profile for use on the genius cluster of the VSC HPC.'
 
         process {
-            clusterOptions = {"--clusters=genius --account=$tier1_project"}
+            clusterOptions = {"--clusters=genius --account=$TIER2_PROJECT"}
             beforeScript   = 'module load cluster/genius/superdome'
             // 6000 - 228 so 228GB for overhead, max is 5910888MB
             resourceLimits = [ memory: 5772.GB, cpus: 14, time: 168.h]

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -1,9 +1,9 @@
 // Default to /tmp directory if $VSC_SCRATCH scratch env is not available,
 // see: https://github.com/nf-core/configs?tab=readme-ov-file#adding-a-new-config
-scratch_dir   = System.getenv("VSC_SCRATCH") ?: "/tmp"
-tier1_project = System.getenv("SLURM_ACCOUNT") ?: null
-avail_queues  = System.getenv("VSC_DEDICATED_QUEUES") ?: null
-def availQueues = avail_queues?.toString()?.split(',')
+scratch_dir         = System.getenv("VSC_SCRATCH") ?: "/tmp"
+tier1_project       = System.getenv("SLURM_ACCOUNT") ?: null
+def avail_queues    = System.getenv("VSC_DEDICATED_QUEUES") ?: ""
+def availQueues     = avail_queues.toString().split(',')
 
 // Perform work directory cleanup when the run has succesfully completed
 // cleanup = true

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -47,12 +47,6 @@ aws {
     maxErrorRetry = 3
 }
 
-// Define a function to call the correct account based on queue
-// TODO: FIX THIS FUNCTION
-def setClusterOptions(queue, defaultAccount, dedicatedAccount) {
-    queue =~ /dedicated/ ? "--clusters=wice --account=${dedicatedAccount}" : "--clusters=wice --account=${defaultAccount}"
-}
-
 // Define profiles for each cluster
 profiles {
     genius {

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -127,7 +127,7 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 			// Set clusterOptions, changing account based on queue
-            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
+            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project --nodes=1"
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -95,13 +95,17 @@ def limitTaskTime(time, maxTime) {
  *     @return Queue name based on task requirements
 */
 def determineGeniusQueue = { task ->
-    if (task.memory >= MEMORY_THRESHOLD_GENIUS) {
-        if (task.time >= TIME_THRESHOLD) {
-            return AVAILABLE_QUEUES.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem_long'
-        }
-        return 'bigmem'
+    def isHighMemory = task.memory >= MEMORY_THRESHOLD_GENIUS
+    def isLongRunning = task.time >= TIME_THRESHOLD
+    def hasDedicatedBigmem = AVAILABLE_QUEUES.contains('dedicated_big_bigmem')
+
+    if (isHighMemory) {
+        return isLongRunning ?
+            (hasDedicatedBigmem ? 'dedicated_big_bigmem' : 'bigmem_long') :
+            'bigmem'
     }
-    return task.time >= TIME_THRESHOLD ? 'batch_long' : 'batch'
+
+    return isLongRunning ? 'batch_long' : 'batch'
 }
 
 /*
@@ -111,14 +115,22 @@ def determineGeniusQueue = { task ->
  *     @return GPU queue name based on task requirements
 */
 def determineGeniusGpuQueue = { task ->
-    if (task.memory >= MEMORY_THRESHOLD_GENIUS) {
-        return task.time >= TIME_THRESHOLD ? 'gpu_v100_long' : 'gpu_v100'
+    def isHighMemory = task.memory >= MEMORY_THRESHOLD_GENIUS
+    def isLongRunning = task.time >= TIME_THRESHOLD
+    def hasDedicatedGpu = AVAILABLE_QUEUES.contains('dedicated_rega_gpu')
+    def hasAmdGpu = AVAILABLE_QUEUES.contains('amd')
+
+    if (isHighMemory) {
+        return isLongRunning ? 'gpu_v100_long' : 'gpu_v100'
     }
-    if (task.time >= TIME_THRESHOLD) {
-        return AVAILABLE_QUEUES.contains('dedicated_rega_gpu') ? 'dedicated_rega_gpu' :
-        AVAILABLE_QUEUES.contains('amd') ? 'amd_long' : 'gpu_p100_long'
+
+    if (isLongRunning) {
+        if (hasDedicatedGpu) return 'dedicated_rega_gpu'
+        if (hasAmdGpu) return 'amd_long'
+        return 'gpu_p100_long'
     }
-    return AVAILABLE_QUEUES.contains('amd') ? 'amd' : 'gpu_p100'
+
+    return hasAmdGpu ? 'amd' : 'gpu_p100'
 }
 
 /*
@@ -128,16 +140,19 @@ def determineGeniusGpuQueue = { task ->
  *     @return Queue name based on task requirements and availability
 */
 def determineWiceQueue = { task ->
-    if (task.memory >= MEMORY_THRESHOLD_WICE) {
-        if (AVAILABLE_QUEUES.contains('dedicated_big_bigmem')) {
+    def isHighMemory = task.memory >= MEMORY_THRESHOLD_WICE
+    def isLongRunning = task.time >= TIME_THRESHOLD
+    def hasDedicatedQueue = AVAILABLE_QUEUES.contains('dedicated_big_bigmem')
+
+    if (isHighMemory) {
+        if (isLongRunning && hasDedicatedQueue) {
             return 'dedicated_big_bigmem'
-        } else {
-            task.time = limitTaskTime(task.time, TIME_THRESHOLD)
-            return 'bigmem,hugemem'
         }
+        task.time = limitTaskTime(task.time, TIME_THRESHOLD)
+        return 'bigmem,hugemem'
     }
 
-    return task.time >= TIME_THRESHOLD ?
+    return isLongRunning ?
         'batch_long,batch_icelake_long,batch_sapphirerapids_long' :
         'batch,batch_sapphirerapids,batch_icelake'
 }
@@ -150,19 +165,20 @@ def determineWiceQueue = { task ->
 */
 def determineWiceGpuQueue = { task ->
     def isHighMemory = task.memory >= MEMORY_THRESHOLD_WICE
-    def isDedicatedQueue = isHighMemory ?
+    def isLongRunning = task.time >= TIME_THRESHOLD
+    def hasDedicatedQueue = isHighMemory ?
         AVAILABLE_QUEUES.contains('dedicated_big_gpu_h100') :
         AVAILABLE_QUEUES.contains('dedicated_big_gpu')
 
-    if (task.time >= TIME_THRESHOLD && !isDedicatedQueue) {
+    if (isLongRunning && !hasDedicatedQueue) {
         task.time = limitTaskTime(task.time, TIME_THRESHOLD)
     }
 
     if (isHighMemory) {
-        return isDedicatedQueue ? 'dedicated_big_gpu_h100' : 'gpu_h100'
-    } else {
-        return isDedicatedQueue ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
+        return (isLongRunning && hasDedicatedQueue) ? 'dedicated_big_gpu_h100' : 'gpu_h100'
     }
+
+    return (isLongRunning && hasDedicatedQueue) ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
 }
 
 /*

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -2,6 +2,8 @@
 // see: https://github.com/nf-core/configs?tab=readme-ov-file#adding-a-new-config
 scratch_dir   = System.getenv("VSC_SCRATCH") ?: "/tmp"
 tier1_project = System.getenv("SLURM_ACCOUNT") ?: null
+avail_queues  = System.getenv("VSC_DEDICATED_QUEUES") ?: null
+def availQueues = avail_queues?.toString()?.split(',')
 
 // Perform work directory cleanup when the run has succesfully completed
 // cleanup = true
@@ -47,6 +49,11 @@ aws {
     maxErrorRetry = 3
 }
 
+// Function to limit task time when dedicated queues are not available
+def limitTaskTime(time, maxTime) {
+    return time > maxTime ? maxTime : time
+}
+
 // Define profiles for each cluster
 profiles {
     genius {
@@ -68,6 +75,8 @@ profiles {
                 resourceLimits         = [ memory: 703.GB, cpus: 36 , time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
+                
+                // Set clusteroptions
                 clusterOptions         = {
                     // suggested to use 9 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/9) as int)
@@ -104,7 +113,7 @@ profiles {
             }
         }
     }
-
+    
     wice {
         params.config_profile_description = 'wice profile for use on the Wice cluster of the VSC HPC.'
 
@@ -112,19 +121,26 @@ profiles {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-
+                        
             // Set queue
+            // The task time is limites to 72 hours if the memory is larger than 239GB
+            // and dedicated queues are not available
             queue = {
-                task.memory >= 239.GB ?
-                    (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
-                    (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
+                def maxTime = 72.h
+                if (task.memory >= 239.GB) {
+                    task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_bigmem') ? 
+                        limitTaskTime(task.time, maxTime) : task.time
+                    return availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem'
+                } else {
+                    return task.time >= maxTime ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake'
+                }
             }
-
+            
             // Set clusterOptions, changing account based on queue
             clusterOptions = {
                 def queueValue = {
-                    task.memory >= 239.GB ?
-                        (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
+                    task.memory >= 239.GB ? 
+                        (task.time >= 72.h && availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem') : 
                         (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
                 }
                 queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
@@ -134,19 +150,31 @@ profiles {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
+                
+                // Set queue
+                // The task time is limites to 72 hours if the memory is larger than 239GB
+                // and dedicated queues are not available
                 queue = {
-                    task.memory >= 239.GB ?
-                        (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                        (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                    def maxTime = 72.h
+                    if (task.memory >= 239.GB) {
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ? 
+                            limitTaskTime(task.time, maxTime) : task.time
+                        return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
+                    } else {
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ? 
+                            limitTaskTime(task.time, maxTime) : task.time
+                        return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
+                    }
                 }
+                
                 clusterOptions = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
                     // Do same queue evaluation as above
                     def queueValue = {
-                        task.memory >= 239.GB ?
-                            (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                            (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                        task.memory >= 239.GB ? 
+                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') : 
+                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                     }
 
                     // Set clusterOptions, changing account based on queue
@@ -167,19 +195,31 @@ profiles {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
+                // Set queue
+                // The task time is limites to 72 hours if the memory is larger than 239GB
+                // and dedicated queues are not available
             queue = {
-                task.memory >= 239.GB ?
-                    (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                    (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                    def maxTime = 72.h
+                    if (task.memory >= 239.GB) {
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ? 
+                            limitTaskTime(task.time, maxTime) : task.time
+                        return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
+                    } else {
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ? 
+                            limitTaskTime(task.time, maxTime) : task.time
+                        return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
+                    }
             }
+            
+            // Set clusteroptions
             clusterOptions = {
                 // suggested to use 16 cpus per gpu
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                // Do same queue evaluation as above
+                // Do same queue evaluation as above, without adjusting task.time
                 def queueValue = {
-                    task.memory >= 239.GB ?
-                        (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
-                        (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                    task.memory >= 239.GB ? 
+                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') : 
+                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                 }
 
                 // Set clusterOptions, changing account based on queue

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -121,7 +121,7 @@ profiles {
             }
 
             // Set clusterOptions, changing account based on queue
-            clusterOptions = { 
+            clusterOptions = {
                 def queueValue = {
                     task.memory >= 239.GB ?
                         (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
@@ -167,7 +167,7 @@ profiles {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-			queue = {
+            queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                     (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -126,8 +126,8 @@ profiles {
                     (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
-						clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project" : "--clusters=wice --account=$tier1_project"
-            // Set clusterOptions based on the evaluated queue
+			// Set clusterOptions, changing account based on queue
+            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
@@ -141,7 +141,8 @@ profiles {
                 clusterOptions = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-										queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+                    // Set clusterOptions, changing account based on queue
+					queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
                 }
             }
         }
@@ -163,9 +164,9 @@ profiles {
             }
             clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                // Set clusterOptions based on queue
-								queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
-						}
+                // Set clusterOptions, changing account based on queue
+				queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+            }
         }
     }
 

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -113,15 +113,23 @@ profiles {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-
-            // Define the queue closure
+            
+            // Set queue
             queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
-			// Set clusterOptions, changing account based on queue
-            clusterOptions = { queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project" }
+            
+            // Set clusterOptions, changing account based on queue
+            clusterOptions = { 
+                def queueValue = {
+                    task.memory >= 239.GB ?
+                        (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
+                        (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
+                }
+                queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project" 
+            }
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
@@ -135,8 +143,17 @@ profiles {
                 clusterOptions = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
+                    // Do same queue evaluation as above
+                    def queueValue = {
+                        task.memory >= 239.GB ?
+                            (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
+                            (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                    }
+                    
                     // Set clusterOptions, changing account based on queue
-					queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+                    queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
+                    queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
+                    "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
                 }
             }
         }
@@ -151,15 +168,25 @@ profiles {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-						queue = {
+			queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                     (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
             }
             clusterOptions = {
+                // suggested to use 16 cpus per gpu
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
+                // Do same queue evaluation as above
+                def queueValue = {
+                    task.memory >= 239.GB ?
+                        (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
+                        (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                }
+                
                 // Set clusterOptions, changing account based on queue
-				queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+                queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
+                queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
+                "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
             }
         }
     }

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -75,7 +75,7 @@ profiles {
                 resourceLimits         = [ memory: 703.GB, cpus: 36 , time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
-                
+
                 // Set clusteroptions
                 clusterOptions         = {
                     // suggested to use 9 cpus per gpu
@@ -113,7 +113,7 @@ profiles {
             }
         }
     }
-    
+
     wice {
         params.config_profile_description = 'wice profile for use on the Wice cluster of the VSC HPC.'
 
@@ -121,26 +121,26 @@ profiles {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-                        
+
             // Set queue
             // The task time is limites to 72 hours if the memory is larger than 239GB
             // and dedicated queues are not available
             queue = {
                 def maxTime = 72.h
                 if (task.memory >= 239.GB) {
-                    task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_bigmem') ? 
+                    task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_bigmem') ?
                         limitTaskTime(task.time, maxTime) : task.time
                     return availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem'
                 } else {
                     return task.time >= maxTime ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake'
                 }
             }
-            
+
             // Set clusterOptions, changing account based on queue
             clusterOptions = {
                 def queueValue = {
-                    task.memory >= 239.GB ? 
-                        (task.time >= 72.h && availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem') : 
+                    task.memory >= 239.GB ?
+                        (task.time >= 72.h && availQueues.contains('dedicated_big_bigmem') ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                         (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
                 }
                 queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
@@ -157,11 +157,11 @@ profiles {
                 queue = {
                     def maxTime = 72.h
                     if (task.memory >= 239.GB) {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ? 
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ?
                             limitTaskTime(task.time, maxTime) : task.time
                         return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
                     } else {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ? 
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ?
                             limitTaskTime(task.time, maxTime) : task.time
                         return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
                     }
@@ -173,7 +173,7 @@ profiles {
                     // Do same queue evaluation as above
                     def queueValue = {
                         task.memory >= 239.GB ? 
-                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') : 
+                            (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                             (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                     }
 
@@ -201,11 +201,11 @@ profiles {
             queue = {
                     def maxTime = 72.h
                     if (task.memory >= 239.GB) {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ? 
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu_h100') ?
                             limitTaskTime(task.time, maxTime) : task.time
                         return availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100'
                     } else {
-                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ? 
+                        task.time = task.time >= maxTime && !availQueues.contains('dedicated_big_gpu') ?
                             limitTaskTime(task.time, maxTime) : task.time
                         return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
                     }
@@ -217,8 +217,8 @@ profiles {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
                 // Do same queue evaluation as above, without adjusting task.time
                 def queueValue = {
-                    task.memory >= 239.GB ? 
-                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') : 
+                    task.memory >= 239.GB ?
+                        (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                         (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                 }
 

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -126,9 +126,8 @@ profiles {
                     (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
-
+						clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project" : "--clusters=wice --account=$tier1_project"
             // Set clusterOptions based on the evaluated queue
-            clusterOptions = setClusterOptions(queue, tier1_project, 'lp_big_wice_cpu')
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
@@ -142,7 +141,7 @@ profiles {
                 clusterOptions = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                    setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
+										queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
                 }
             }
         }
@@ -165,10 +164,8 @@ profiles {
             clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
                 // Set clusterOptions based on queue
-                setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
-            }
-
-            
+								queue =~ /dedicated/ ? "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}" : "--clusters=wice --account=$tier1_project --gres=gpu:${gpus}"
+						}
         }
     }
 

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -83,7 +83,6 @@ profiles {
         }
     }
 
-
     genius_gpu {
         params.config_profile_description = 'genius_gpu profile for use on the genius cluster of the VSC HPC.'
         apptainer.runOptions              = '--containall --cleanenv --nv'
@@ -113,14 +112,14 @@ profiles {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-            
+
             // Set queue
             queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
-            
+
             // Set clusterOptions, changing account based on queue
             clusterOptions = { 
                 def queueValue = {
@@ -128,7 +127,7 @@ profiles {
                         (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                         (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
                 }
-                queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project" 
+                queueValue() =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
             }
 
             withLabel: '.*gpu.*' {
@@ -149,7 +148,7 @@ profiles {
                             (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                             (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                     }
-                    
+
                     // Set clusterOptions, changing account based on queue
                     queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
                     queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :
@@ -182,7 +181,7 @@ profiles {
                         (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                         (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                 }
-                
+
                 // Set clusterOptions, changing account based on queue
                 queueValue() =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :
                 queueValue() =~ /dedicated_big_gpu/ ? "--clusters=wice --account=lp_big_wice_gpu --gres=gpu:${gpus}" :

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -121,7 +121,7 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 			// Set clusterOptions, changing account based on queue
-            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
+            clusterOptions = { queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project" }
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -121,7 +121,6 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 			// Set clusterOptions, changing account based on queue
-            // Set clusterOptions, changing account based on queue
             clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
 
             withLabel: '.*gpu.*' {

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -47,6 +47,12 @@ aws {
     maxErrorRetry = 3
 }
 
+// Define a function to call the correct account based on queue
+// TODO: FIX THIS FUNCTION
+def setClusterOptions(queue, defaultAccount, dedicatedAccount) {
+    queue.toString.contains('dedicated') ? "--clusters=wice --account=${dedicatedAccount}" : "--clusters=wice --account=${defaultAccount}"
+}
+
 // Define profiles for each cluster
 profiles {
     genius {
@@ -112,7 +118,7 @@ profiles {
         process {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
-            clusterOptions = { "--clusters=wice --account=$tier1_project"}
+            clusterOptions = { "--clusters=wice --account=$tier1_project" }
             beforeScript   = 'module load cluster/wice'
 
             queue = {
@@ -121,14 +127,17 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 
-            withLabel: '.*gpu.*'{
+            // Set clusterOptions based on queue
+            clusterOptions = setClusterOptions(queue, tier1_project, 'lp_big_wice_cpu')
+
+            withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
                 clusterOptions         = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                    "--gres=gpu:${gpus} --clusters=wice --account=$tier1_project"
+                    setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
                 }
 
                 queue = {
@@ -139,7 +148,6 @@ profiles {
             }
         }
     }
-
 
     wice_gpu {
         params.config_profile_description = 'wice_gpu profile for use on the Wice cluster of the VSC HPC.'
@@ -152,7 +160,7 @@ profiles {
             beforeScript   = 'module load cluster/wice'
             clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                "--gres=gpu:${gpus} --clusters=wice --account=$tier1_project"
+                setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
             }
 
             queue = {

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -127,7 +127,11 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 			// Set clusterOptions, changing account based on queue
-            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project --nodes=1"
+            if queue =~ /dedicated/ {
+                clusterOptions = "--clusters=wice --account=lp_big_wice_cpu"
+            } else {
+                clusterOptions = "--clusters=wice --account=$tier1_project"
+            }
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -150,7 +150,7 @@ profiles {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
-                
+
                 // Set queue
                 // The task time is limites to 72 hours if the memory is larger than 239GB
                 // and dedicated queues are not available
@@ -166,13 +166,13 @@ profiles {
                         return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
                     }
                 }
-                
+
                 clusterOptions = {
                     // suggested to use 16 cpus per gpu
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
                     // Do same queue evaluation as above
                     def queueValue = {
-                        task.memory >= 239.GB ? 
+                        task.memory >= 239.GB ?
                             (task.time >= 72.h && availQueues.contains('dedicated_big_gpu_h100') ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                             (task.time >= 72.h && availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
                     }
@@ -210,7 +210,7 @@ profiles {
                         return availQueues.contains('dedicated_big_gpu') ? 'dedicated_big_gpu' : 'gpu_a100,gpu'
                     }
             }
-            
+
             // Set clusteroptions
             clusterOptions = {
                 // suggested to use 16 cpus per gpu

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -115,9 +115,10 @@ def determineGeniusGpuQueue = { task ->
         return task.time >= TIME_THRESHOLD ? 'gpu_v100_long' : 'gpu_v100'
     }
     if (task.time >= TIME_THRESHOLD) {
-        return AVAILABLE_QUEUES.contains('dedicated_rega_gpu') ? 'dedicated_rega_gpu' : 'gpu_p100_long,amd_long'
+        return AVAILABLE_QUEUES.contains('dedicated_rega_gpu') ? 'dedicated_rega_gpu' :
+        AVAILABLE_QUEUES.contains('amd') ? 'amd_long' : 'gpu_p100_long'
     }
-    return 'gpu_p100,amd'
+    return AVAILABLE_QUEUES.contains('amd') ? 'amd' : 'gpu_p100'
 }
 
 /*
@@ -183,7 +184,7 @@ profiles {
         process {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 36, time: 168.h ]
-            beforeScript   = 'module load cluster/genius'
+            beforeScript   = { 'module load cluster/genius/' + determineGeniusQueue(task).toString().split(',')[0] }
             queue          = { determineGeniusQueue(task) }
             clusterOptions = {
                 determineGeniusQueue(task) =~ /dedicated/ ?
@@ -193,6 +194,7 @@ profiles {
 
             withLabel: '.*gpu.*'{
                 resourceLimits         = [ memory: 703.GB, cpus: 36 , time: 168.h ]
+                beforeScript           = { 'module load cluster/genius/' + determineGeniusGpuQueue(task).toString().split(',')[0] }
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
                 queue                  = { determineGeniusGpuQueue(task) }
@@ -212,8 +214,8 @@ profiles {
         process {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 36, time: 168.h]
-            beforeScript   = 'module load cluster/genius'
-            queue         = { determineGeniusGpuQueue(task) }
+            beforeScript   = { 'module load cluster/genius/' + determineGeniusGpuQueue(task).toString().split(',')[0] }
+            queue          = { determineGeniusGpuQueue(task) }
             clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/9) as int)
                 "--gres=gpu:${gpus} --clusters=genius --account=$TIER2_PROJECT"
@@ -227,7 +229,7 @@ profiles {
         process {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
-            beforeScript   = 'module load cluster/wice'
+            beforeScript   = { 'module load cluster/wice/' + determineWiceQueue(task).toString().split(',')[0] }
             queue          = { determineWiceQueue(task) }
             clusterOptions = {
                 determineWiceQueue(task) =~ /dedicated/ ?
@@ -239,6 +241,7 @@ profiles {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
+                beforeScript           = { 'module load cluster/wice/' + determineWiceGpuQueue(task).toString().split(',')[0] }
                 queue                  = { determineWiceGpuQueue(task) }
                 clusterOptions         = {
                     def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
@@ -258,10 +261,10 @@ profiles {
 
         process {
             // 768 - 65 so 65GB for overhead, max is 720000MB
-            beforeScript           = 'module load cluster/wice'
-            resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
-            queue                  = { determineWiceGpuQueue(task) }
-            clusterOptions         = {
+            beforeScript   = { 'module load cluster/wice/' + determineWiceGpuQueue(task).toString().split(',')[0] }
+            resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
+            queue          = { determineWiceGpuQueue(task) }
+            clusterOptions = {
                 def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
                 def queueValue = determineWiceGpuQueue(task)
                 queueValue =~ /dedicated_big_gpu_h100/ ? "--clusters=wice --account=lp_big_wice_gpu_h100 --gres=gpu:${gpus}" :

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -121,11 +121,8 @@ profiles {
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 			// Set clusterOptions, changing account based on queue
-            if queue =~ /dedicated/ {
-                clusterOptions = "--clusters=wice --account=lp_big_wice_cpu"
-            } else {
-                clusterOptions = "--clusters=wice --account=$tier1_project"
-            }
+            // Set clusterOptions, changing account based on queue
+            clusterOptions = queue =~ /dedicated/ ? "--clusters=wice --account=lp_big_wice_cpu" : "--clusters=wice --account=$tier1_project"
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]

--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -50,7 +50,7 @@ aws {
 // Define a function to call the correct account based on queue
 // TODO: FIX THIS FUNCTION
 def setClusterOptions(queue, defaultAccount, dedicatedAccount) {
-    queue.toString.contains('dedicated') ? "--clusters=wice --account=${dedicatedAccount}" : "--clusters=wice --account=${defaultAccount}"
+    queue =~ /dedicated/ ? "--clusters=wice --account=${dedicatedAccount}" : "--clusters=wice --account=${defaultAccount}"
 }
 
 // Define profiles for each cluster
@@ -118,32 +118,31 @@ profiles {
         process {
             // max is 2016000
             resourceLimits = [ memory: 1968.GB, cpus: 72, time: 168.h ]
-            clusterOptions = { "--clusters=wice --account=$tier1_project" }
             beforeScript   = 'module load cluster/wice'
 
+            // Define the queue closure
             queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_bigmem' : 'bigmem,hugemem') :
                     (task.time >= 72.h ? 'batch_long,batch_icelake_long,batch_sapphirerapids_long' : 'batch,batch_sapphirerapids,batch_icelake')
             }
 
-            // Set clusterOptions based on queue
+            // Set clusterOptions based on the evaluated queue
             clusterOptions = setClusterOptions(queue, tier1_project, 'lp_big_wice_cpu')
 
             withLabel: '.*gpu.*' {
                 resourceLimits         = [ memory: 703.GB, cpus: 64, time: 168.h ]
                 apptainer.runOptions   = '--containall --cleanenv --nv'
                 singularity.runOptions = '--containall --cleanenv --nv'
-                clusterOptions         = {
-                    // suggested to use 16 cpus per gpu
-                    def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                    setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
-                }
-
                 queue = {
                     task.memory >= 239.GB ?
                         (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                         (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
+                }
+                clusterOptions = {
+                    // suggested to use 16 cpus per gpu
+                    def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
+                    setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
                 }
             }
         }
@@ -158,16 +157,18 @@ profiles {
             // 768 - 65 so 65GB for overhead, max is 720000MB
             resourceLimits = [ memory: 703.GB, cpus: 64, time: 168.h ]
             beforeScript   = 'module load cluster/wice'
-            clusterOptions = {
-                def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
-                setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
-            }
-
-            queue = {
+						queue = {
                 task.memory >= 239.GB ?
                     (task.time >= 72.h ? 'dedicated_big_gpu_h100' : 'gpu_h100') :
                     (task.time >= 72.h ? 'dedicated_big_gpu' : 'gpu_a100,gpu')
             }
+            clusterOptions = {
+                def gpus = task.accelerator?.request ?: Math.max(1, Math.floor((task.cpus ?:1)/16) as int)
+                // Set clusterOptions based on queue
+                setClusterOptions(queue, tier1_project, 'lp_big_wice_gpu') + " --gres=gpu:${gpus}"
+            }
+
+            
         }
     }
 

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -15,7 +15,7 @@ A nextflow module is available that can be loaded `module load Nextflow` but it 
 2. Set up the environment variables in `~/.bashrc` or `~/.bash_profile`:
 
 :::note
-If you have access to dedicated nodes, you can export these as a command separated list. These queues will only be used if specified task requirements are not available in the normal partitions but they are available in dedicated partitions.
+If you have access to dedicated nodes, you can export these as a command separated list. These queues will only be used if specified task requirements are not available in the normal partitions but they are available in dedicated partitions. AMD is considered a dedicated partition.
 :::
 
 ```bash

--- a/docs/vsc_kul_uhasselt.md
+++ b/docs/vsc_kul_uhasselt.md
@@ -14,8 +14,16 @@ A nextflow module is available that can be loaded `module load Nextflow` but it 
 
 2. Set up the environment variables in `~/.bashrc` or `~/.bash_profile`:
 
+:::note
+If you have access to dedicated nodes, you can export these as a command separated list. These queues will only be used if specified task requirements are not available in the normal partitions but they are available in dedicated partitions.
+:::
+
 ```bash
 export SLURM_ACCOUNT="<your-credential-account>"
+
+# Comma-separated list of available dedicated partitions (if any)
+# For example: export VSC_DEDICATED_QUEUES="dedicated_big_bigmem,dedicated_big_gpu"
+export VSC_DEDICATED_QUEUES="<available-dedicated-partitions>"
 
 # Needed for running Nextflow jobs
 export NXF_HOME="$VSC_SCRATCH/.nextflow"


### PR DESCRIPTION
You recently added the dedicated nodes as possible partitions. However, since there is only `$SLURM_ACCOUNT` is used as the `--account`. Nextflow submissions will fail because the dedicated nodes have different `--account` requirements. 

This PR has changes to dynamically evaluate whether the outcome of the queue variable is one of the dedicated nodes and will give change the `--account` cluster option based on this. Another option is to have users specify multiple environment variables and call these instead of the hardcoded `--account` in clusterOptions like I have done now. 

Since there are issues with evaluating `queue`, I repeated the queue definition statement. It's a bit ugly so if you have other suggestions, feel free.

I have only tested this config for the dedicated vs non-dedicated CPU nodes, not for the gpu or the gpu_h100.
