### PR TITLE
Update eddie.config singularity runtime options

### DIFF
--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -46,7 +46,7 @@ env {
 
 singularity {
     envWhitelist = "SINGULARITY_TMPDIR,TMPDIR"
-    runOptions   = '-p -B "$TMPDIR"'
+    runOptions   = '-p --scratch /dev/shm -B "$TMPDIR"'
     enabled      = true
     autoMounts   = true
     cacheDir     = "/exports/igmm/eddie/BioinformaticsResources/nfcore/singularity-images"


### PR DESCRIPTION
add --scratch /dev/shm to singularity runtime options to help singularity verstion 4 run on eddie HPC
