### PR TITLE
update biohpc_gen config to reduce load on slurm DB

### DIFF
--- a/conf/biohpc_gen.config
+++ b/conf/biohpc_gen.config
@@ -14,6 +14,15 @@ process {
     executor       = 'slurm'
     queue          = { task.memory <= 1536.GB ? (task.time > 2.d || task.memory > 384.GB ? 'biohpc_gen_production' : 'biohpc_gen_normal') : 'biohpc_gen_highmem' }
     clusterOptions = '--clusters=biohpc_gen'
+    array = 25
+}
+
+executor {
+    $slurm {
+        queueStatInterval = '10 min'
+        pollInterval = '30 sec'
+        submitRateLimit = '25sec'
+    }
 }
 
 charliecloud {

--- a/docs/biohpc_gen.md
+++ b/docs/biohpc_gen.md
@@ -44,4 +44,6 @@ These are then available as modules (please confirm the module name using module
 module load nextflow/24.04.2-gcc12 charliecloud/0.35-gcc12
 ```
 
-> NB: Nextflow will need to submit the jobs via the job scheduler to the HPC cluster and as such the commands above will have to be executed on one of the login nodes.
+> NB: bioHPC compute nodes are submit hosts. This means you can submit the nextflow head job via sbatch.
+
+> NB: Sometimes you may want to have jobs submitted 'locally' in a large nextflow job. Details on this can be found here https://doku.lrz.de/nextflow-on-hpc-systems-test-operation-788693597.html


### PR DESCRIPTION
This is a config update to reduce queries to the slurm DB by nextflow. These changes were made after discussion with the datacenter (LRZ). The main changes are: 

- increasing `queueStatInterval`
- using arrays
- rate limiting submissions
