### PR TITLE
Fallout from name change: #uppmax channel is now #helpdesk-hpc-sweden

### DIFF
--- a/docs/pdc_kth.md
+++ b/docs/pdc_kth.md
@@ -4,6 +4,11 @@ nf-core pipelines have been successfully configured for use on the PDC
 cluster dardel. No other clusters have yet been tested, but support can be
 added if needed.
 
+## Getting help
+
+We have a channel dedicated to assist Swedish HPC users users on the nf-core
+Slack: [https://nfcore.slack.com/channels/helpdesk-hpc-sweden](https://nfcore.slack.com/channels/helpdesk-hpc-sweden)
+
 ## Getting started
 
 The base java installation on dardel is Java 11. By loading the `PDC`

--- a/docs/uppmax.md
+++ b/docs/uppmax.md
@@ -5,7 +5,7 @@ All nf-core pipelines have been successfully configured for use on the Swedish U
 ## Getting help
 
 We have a Slack channel dedicated to assist Swedich HPC users on the nf-core
-Slack: [https://nfcore.slack.com/channels/uppmax](https://nfcore.slack.com/channels/helpdesk-hpc-sweden)
+Slack: [https://nfcore.slack.com/channels/helpdesk-hpc-sweden](https://nfcore.slack.com/channels/helpdesk-hpc-sweden)
 
 ## Using the UPPMAX config profile
 

--- a/docs/uppmax.md
+++ b/docs/uppmax.md
@@ -4,7 +4,8 @@ All nf-core pipelines have been successfully configured for use on the Swedish U
 
 ## Getting help
 
-We have a Slack channel dedicated to UPPMAX users on the nf-core Slack: [https://nfcore.slack.com/channels/uppmax](https://nfcore.slack.com/channels/uppmax)
+We have a Slack channel dedicated to assist Swedich HPC users on the nf-core
+Slack: [https://nfcore.slack.com/channels/uppmax](https://nfcore.slack.com/channels/helpdesk-hpc-sweden)
 
 ## Using the UPPMAX config profile
 


### PR DESCRIPTION
Update docs for UPPMAX to use new slack channel name and reference channel in pdc_kth docs.