### PR TITLE
Update bluebear.config

### DIFF
--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -14,8 +14,6 @@ cleanup = true
 env.TMPDIR = "${scratch_dir}"
 
 // Enable Singularity (via Apptainer) for all processes
-// Singularity engine prefered so pipeline pulls pre-built containers rather than building them
-// (see https://nf-co.re/docs/usage/installation#pipeline-software)
 singularity {
     enabled    = true
     autoMount  = true
@@ -28,9 +26,13 @@ process {
         cpus: 112,
         time: 10.d
     ]
+
+    // Slurm executor
     executor       = 'slurm'
     clusterOptions = "--account ${System.getenv("SLURM_JOB_ACCOUNT")}"
-    beforeScript   = "mkdir -p ${scratch_dir}" // Ensure scratch directory exists
+
+    // Ensure scratch directory exists
+    beforeScript   = "mkdir -p ${scratch_dir}"
 }
 
 executor {

--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -23,9 +23,7 @@ process {
         time: 10.d
     ]
     executor       = 'slurm'
-    clusterOptions = {
-        "--account ${System.getenv("SLURM_JOB_ACCOUNT")} " + "--qos ${task.time <= 10.m ? 'bbshort' : 'bbdefault'}"
-    }
+    clusterOptions = "--account ${System.getenv("SLURM_JOB_ACCOUNT")}"
 }
 
 executor {

--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -5,6 +5,11 @@ params {
     config_profile_description = 'BlueBEAR cluster profile'
     config_profile_contact     = 'Alex Lyttle (@alexlyttle)'
     config_profile_url         = 'https://docs.bear.bham.ac.uk/'
+
+    // Maximum resources available
+    max_memory                 = 512.GB
+    max_cpus                   = 112
+    max_time                   = 10.d
 }
 
 // Clean up work directory after successful run

--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -30,6 +30,7 @@ process {
     ]
     executor       = 'slurm'
     clusterOptions = "--account ${System.getenv("SLURM_JOB_ACCOUNT")}"
+    beforeScript   = "mkdir -p ${scratch_dir}" // Ensure scratch directory exists
 }
 
 executor {

--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -1,3 +1,5 @@
+def scratch_dir = "/scratch/${System.getenv("USER")}"
+
 params {
     // Profile config
     config_profile_description = 'BlueBEAR cluster profile'
@@ -8,12 +10,16 @@ params {
 // Clean up work directory after successful run
 cleanup = true
 
+// Ensure TMPDIR is set to the node-specific scratch directory
+env.TMPDIR = "${scratch_dir}"
+
 // Enable Singularity (via Apptainer) for all processes
 // Singularity engine prefered so pipeline pulls pre-built containers rather than building them
 // (see https://nf-co.re/docs/usage/installation#pipeline-software)
 singularity {
-    enabled   = true
-    autoMount = true
+    enabled    = true
+    autoMount  = true
+    runOptions = "-B ${scratch_dir}"
 }
 
 process {

--- a/conf/bluebear.config
+++ b/conf/bluebear.config
@@ -3,11 +3,6 @@ params {
     config_profile_description = 'BlueBEAR cluster profile'
     config_profile_contact     = 'Alex Lyttle (@alexlyttle)'
     config_profile_url         = 'https://docs.bear.bham.ac.uk/'
-
-    // Maximum resources available
-    max_memory                 = 512.GB
-    max_cpus                   = 112
-    max_time                   = 10.d
 }
 
 // Clean up work directory after successful run


### PR DESCRIPTION
Some changes after user feedback.

- Add `scratch_dir` variable which points to user scratch local to each compute node
- Set environment variable `TMPDIR` to `scratch_dir` (this is not yet done automatically by the cluster)
- Bind `scratch_dir` to singularity/apptainer via `runOptions`
- Add `beforeScript` to ensure `scratch_dir` exists (the cluster does not currently guarantee this)
- Remove `--qos` from `clusterOptions` as `bbshort` will be deprecated soon

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->