### PR TITLE
Update NYGC config

### DIFF
--- a/conf/nygc.config
+++ b/conf/nygc.config
@@ -9,7 +9,7 @@ singularity {
 
 process {
     executor = 'slurm'
-    queue    = { task.accelerator ? 'gpu' : 'cpu' }
+    queue    = { task.accelerator ? 'gpu' : (task.memory > 100.GB ? 'bigmem' : 'cpu') }
 }
 
 params {


### PR DESCRIPTION

Use `bigmem` partition for tasks requesting over 100Gb of memory