### PR TITLE
catch more exit error code

### DIFF
--- a/conf/stjude.config
+++ b/conf/stjude.config
@@ -32,7 +32,7 @@ process {
     cache          = 'lenient'
 
     maxRetries     = 3
-    errorStrategy  = { task.exitStatus in [143, 137, 134, 139, 140] ? 'retry' : 'finish' }
+    errorStrategy  = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
 
     afterScript    = 'sleep 10'
     // to avoid fail when using storeDir for missing output


### PR DESCRIPTION
---
name:  Patch the existing config
about: change config to catch more error exitcodes
---

On our HPC, the out of memory failures usually throw exit code 130, which isn’t caught by the current line:
```
errorStrategy  = { task.exitStatus in [143, 137, 134, 139, 140] ? 'retry' : 'finish' }
```
Replacing it with the current nf-core default, which was recently expanded to catch additional exit codes as:

```
errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
```

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
