### PR TITLE
Marjorie config: bump resources for m7i-48xlarge instances

### DIFF
--- a/conf/marjorie.config
+++ b/conf/marjorie.config
@@ -7,15 +7,15 @@
 params {
     config_profile_description = "Novo Nordisk's Marjorie cluster profile"
     config_profile_contact     = 'Ashot Margaryan (ashotmarg2004@gmail.com)'
-    max_memory                 = "512.GB"
-    max_cpus                   = 64
+    max_memory                 = "768.GB"
+    max_cpus                   = 96
     max_time                   = "240.h"
 }
 
 process {
     resourceLimits = [
-        memory: 512.GB,
-        cpus: 64,
+        memory: 768.GB,
+        cpus: 96,
         time: 240.h
     ]
     executor     = 'slurm'


### PR DESCRIPTION
`conf/marjorie.config`:  bump resources for m7i-48xlarge instances

@ashotmarg