### PR TITLE
conf/marjorie.config: add default Slurm queue

### DIFF
--- a/conf/marjorie.config
+++ b/conf/marjorie.config
@@ -19,6 +19,7 @@ process {
         time: 240.h
     ]
     executor     = 'slurm'
+    queue        = 'compute'
     scratch      = true
     maxRetries   = 3
     scratch      = "/scratch/${USER}"


### PR DESCRIPTION
`conf/marjorie.config`: add explicit Slurm queue since "interactive" seems to be the default now

@ashotmarg

