### PR TITLE
roslin.config: Few fixes

### DIFF
--- a/conf/roslin.config
+++ b/conf/roslin.config
@@ -16,9 +16,9 @@ process {
 
     // This will override all jobs clusterOptions
     // This is necessary to allow jobs to run on Eddie for many users
-    // For each job, we add an extra 4 Gb of memory.
-    // For example, the process asked 16 Gb of RAM (task.memory). The job will reserve 20 Gb of RAM.
-    // The process will still use 16 Gb (task.memory) leaving 4 Gb for other system processes.
+    // For each job, we add an extra 8 Gb of memory.
+    // For example, the process asked 16 Gb of RAM (task.memory). The job will reserve 24 Gb of RAM.
+    // The process will still use 16 Gb (task.memory) leaving 8 Gb for other system processes.
     // This is very useful any JAVA programs which allocate task.memory RAM for its Virtual Machine
     // Also it leaves enough memory for singularity to unpack images.
     clusterOptions = {
@@ -34,17 +34,13 @@ process {
     maxErrors = '-1'
     maxRetries = 3
 
+    // Force singularity version 3 as version 4 cause FUSE/squashfs issues on Eddie
     beforeScript =
     """
     . /etc/profile.d/modules.sh
-    module load singularity
+    module load igmm/apps/singularity/3
     export SINGULARITY_TMPDIR="\$TMPDIR"
     """
-}
-
-params {
-    // iGenomes reference base
-    igenomes_base = '/exports/igmm/eddie/BioinformaticsResources/igenomes'
 }
 
 env {
@@ -56,6 +52,10 @@ singularity {
     runOptions   = '-p -B "$TMPDIR"'
     enabled      = true
     autoMounts   = true
-    cacheDir     = '/exports/cmvm/eddie/eb/groups/alaw3_eb_singularity_cache'
+    // Define the singularity cache directory depending on the presence of the NFX_SGE_PROJECT variable
+    // User without compute project can't access to the shared cache directory.
+    // So, they need to store singularity images into the work directory.
+    cacheDir     = System.getenv('NFX_SGE_PROJECT') ?
+        "/exports/cmvm/eddie/eb/groups/alaw3_eb_singularity_cache" :
+        null
 }
-


### PR DESCRIPTION
---
name: roslin.config
about: Few fixes for smooth runs
---

- Remove the igenome configuration. IGMM igenome folder is not accessible for Roslin users. 
- Load singularity 3 instead of 4. Version 4 throw squashfs / FUSE error on new nodes. 
- Add logic to define the singularity cache directory. Users who don't use compute project can't access the shared singularity cache.

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
