### PR TITLE
Update munin.config

### DIFF
--- a/conf/pipeline/sarek/munin.config
+++ b/conf/pipeline/sarek/munin.config
@@ -23,7 +23,7 @@ params {
 // Specific nf-core/sarek process configuration
 process {
     withLabel: sentieon {
-        module    = { params.sentieon ? 'sentieon/202112.02' : null }
+        module    = { params.sentieon ? 'sentieon/202112.05' : null }
         container = { params.sentieon ? null : container }
     }
 }


### PR DESCRIPTION
The line:
module    = { params.sentieon ? 'sentieon/202112.02' : null }
was changed to:
module    = { params.sentieon ? 'sentieon/202112.05' : null }

This is required by the Sentieon software having now come up with to a patched version due to their digital certificate being expired and thus renewed. We have set up the patched version  202112.05 now at BTB and we need Sarek to pick up this one instead of the old 202112.02, or it will no longer work with Sentieon.

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
