### PR TITLE
Ggrimes patch 1

### DIFF
--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -15,7 +15,17 @@ process {
         cpus: 32,
         time: 240.h
     ]
-    clusterOptions = { task.memory ? "-l h_vmem=${task.memory.bytes / task.cpus}" : null }
+    clusterOptions = {
+        if( ! task.memory ) {
+            return null
+        }
+	// total bytes requested, divided by slots ⇒ bytes per slot
+        def bytesPerSlot = task.memory.bytes / task.cpus
+        // convert to GB and round up to the next integer
+        def gbPerSlot = Math.ceil( bytesPerSlot / (1024 * 1024 * 1024) as double )
+        // emit SGE flag in “G” units
+        return "-l h_vmem=${gbPerSlot}G"
+    }
     stageInMode    = 'symlink'
     scratch        = 'false'
     penv           = { task.cpus > 1 ? "sharedmem" : null }

--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -19,7 +19,7 @@ process {
         if( ! task.memory ) {
             return null
         }
-	// total bytes requested, divided by slots ⇒ bytes per slot
+        // total bytes requested, divided by slots ⇒ bytes per slot
         def bytesPerSlot = task.memory.bytes / task.cpus
         // convert to GB and round up to the next integer
         def gbPerSlot = Math.ceil( bytesPerSlot / (1024 * 1024 * 1024) as double )


### PR DESCRIPTION
fix the way clusterOptions calculated as HPC admins removed ability to submit memory specifications in bytes

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your custom profile to the `README.md` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
