### PR TITLE
Update unsw_katana gpu to use withLabel:process_gpu

### DIFF
--- a/conf/pipeline/proteinfold/unsw_katana.config
+++ b/conf/pipeline/proteinfold/unsw_katana.config
@@ -1,23 +1,30 @@
 profiles {
     unsw_katana {
         params {
+            config_profile_name        = 'proteinfold/unsw_katana'
             config_profile_contact     = '@jscgh'
             config_profile_description = 'nf-core/proteinfold UNSW Katana profile provided by nf-core/configs'
         }
 
+        // The proteinfold images are predownloaded and stored in the singularity library directory
         apptainer.libraryDir    = "/srv/scratch/sbf-pipelines/proteinfold/singularity"
-        apptainer.cacheDir      = "/srv/scratch/${USER}/.images"
         singularity.libraryDir  = "/srv/scratch/sbf-pipelines/proteinfold/singularity"
-        singularity.cacheDir    = "/srv/scratch/${USER}/.images"
+
+        cleanup = true
 
         process {
             executor = 'pbspro'
 
-            if (params.use_gpu) { clusterOptions = { "-l select=1:ngpus=1:ncpus=8:mem=125gb" } }
-
             withName: 'RUN_HELIXFOLD3' {
-                containerOptions    = "--bind \${TMPDIR}:/tmp,\${PWD} --env CUDA_VISIBLE_DEVICES=0"
+                clusterOptions  = { "-l select=1:ngpus=1:ncpus=6:mem=62gb:gpu_model=A100" } // Using A100 GPU for compatibility
             }
+            withName: 'RUN_ESMFOLD' {
+                clusterOptions  = { "-l select=1:ngpus=1:ncpus=6:mem=62gb:gpu_model=A100" } // Using A100 GPU for compatibility
+            }
+            withName: 'RUN_ALPHAFOLD2_PRED|RUN_ALPHAFOLD2' {
+                clusterOptions  = { "-l select=1:ngpus=1:ncpus=8:mem=250gb:gpu_model=H200" } // Using H200 GPU for highest performance
+            }
+
         }
     }
 }

--- a/conf/unsw_katana.config
+++ b/conf/unsw_katana.config
@@ -1,14 +1,17 @@
 // UNSW Katana nf-core configuration profile
 
-
 params {
-    config_profile_description = 'UNSW Katana HPC profile provided by nf-core/configs.'
-    config_profile_contact = '@jscgh'
-    config_profile_url = 'https://docs.restech.unsw.edu.au/'
+    config_profile_name         = 'unsw_katana'
+    config_profile_description  = 'UNSW Katana HPC profile provided by nf-core/configs.'
+    config_profile_contact      = '@jscgh'
+    config_profile_url          = 'https://docs.restech.unsw.edu.au/'
 }
 
 process {
     executor = 'pbspro'
+
+    // Load required modules for running Nextflow
+    beforeScript = 'module load nextflow java'
 
     resourceLimits = [
     memory: 248.GB,
@@ -16,6 +19,11 @@ process {
     time: 100.h
     ]
 
+    // Basic GPU node allocation
+    withLabel:process_gpu {
+        accelerator     = 1
+        clusterOptions  = { "-l select=1:ngpus=1:ncpus=6:mem=125gb" }
+    }
     withLabel:process_single {
         cpus   = { 1                       }
         memory = { 4.GB     * task.attempt }
@@ -27,8 +35,8 @@ process {
         time   = { 2.h      * task.attempt }
     }
     withLabel:process_medium {
-        cpus   = { 8        * task.attempt }
-        memory = { 62.GB    * task.attempt }
+        cpus   = { 6        * task.attempt }
+        memory = { 46.GB    * task.attempt }
         time   = { 12.h     * task.attempt }
     }
     withLabel:process_high {
@@ -49,4 +57,19 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 1
     }
+}
+
+// Set the cache directory for Singularity and Apptainer
+singularity {
+    autoMounts = true
+    cacheDir = "/srv/scratch/${USER}/.images"
+}
+apptainer {
+    autoMounts = true
+    cacheDir = "/srv/scratch/${USER}/.images"
+}
+
+// Docker is not supported on this cluster
+docker {
+    enabled = false
 }

--- a/docs/unsw_katana.md
+++ b/docs/unsw_katana.md
@@ -1,8 +1,8 @@
-# nf-core/configs: USNW Katana HPC Configuration
+# nf-core/configs: UNSW Katana HPC Configuration
 
 nf-core pipelines have been successfully configured for use on the [UNSW Katana](https://docs.restech.unsw.edu.au/) at the University of New South Wales, Sydney, Australia.
 
-To run an nf-core pipeline at UNSW Katana, run the pipeline with `-profile singularity,unsw_katana`. This will download and launch the [`unsw_katana.config`](../conf/unsw_katana.config) which has been pre-configured with a setup suitable for the unsw katana HPC cluster. Using this profile, a Singularity image image containing all of the required software will be used for the pipeline.
+To run an nf-core pipeline at UNSW Katana, run the pipeline with `-profile singularity,unsw_katana`. This will download and launch the [`unsw_katana.config`](../conf/unsw_katana.config) which has been pre-configured with a setup suitable for the unsw katana HPC cluster. Using this profile, a Singularity image containing all of the required software will be used for the pipeline.
 
 ## Launch an nf-core pipeline on Katana
 
@@ -18,14 +18,13 @@ module load nextflow java
 ### Execution command
 
 ```bash
-module load nextflow
-module load java
-
 nextflow run <nf-core_pipeline>/main.nf \
     -profile singularity,unsw_katana \
     <additional flags>
-```
+
+# Replace `<nf-core_pipeline>` with the name of the nf-core pipeline you want to run, e.g., `nf-core/proteinfold`.
 
 ### Queue limits
 
 This config is defined in line with the [UNSW Katana queue limits](https://docs.restech.unsw.edu.au/using_katana/running_jobs/#job-queue-limits-summary).
+```


### PR DESCRIPTION
---
Add `process_gpu` as a label
---

This adds the option of a `process_gpu` label being used in pipelines to route gpu enabled steps.

Please follow these steps before submitting your PR:

- [x] Your PR targets the `master` branch