### PR TITLE
Update PDC_KTH config for strict syntax

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -1,9 +1,9 @@
 // Nextflow config for use with PDC at KTH
 
 params {
-    project                      = null // Naiss project allocation
-    clusterOptions               = null
-    clusterName                  = {
+    project                    = null // Naiss project allocation
+    clusterOptions             = null
+    clusterName                = {
         def cluster = "unknown"
         try {
             cluster = ['/bin/bash', '-c', 'sacctmgr show cluster -n | grep -o "^\s*[^ ]*\s*"'].execute().text.trim()
@@ -14,15 +14,15 @@ params {
         cluster
     }.call()
 
-    config_profile_description   = 'PDC profile.'
-    config_profile_contact       = 'Pontus Freyhult (@pontus)'
-    config_profile_url           = "https://www.pdc.kth.se/"
+    config_profile_description = 'PDC profile.'
+    config_profile_contact     = 'Pontus Freyhult (@pontus)'
+    config_profile_url         = "https://www.pdc.kth.se/"
 
-    max_memory                   = 1790.GB
-    max_cpus                     = 256
-    max_time                     = 7.d
+    max_memory                 = 1790.GB
+    max_cpus                   = 256
+    max_time                   = 7.d
 
-    ignore_params_list           = [
+    ignore_params_list         = [
         "cluster-options",
         "clusterOptions",
         "clusterName",
@@ -34,10 +34,19 @@ params {
         "max_time",
         "project",
         "schema_ignore_params",
-        "validationSchemaIgnoreParams"
-        ]
+        "validationSchemaIgnoreParams",
+    ]
 }
 
+// nf-schema/nf-validation settings
+// Different versions use different specifications
+validation {
+    ignoreParams = params.ignore_params_list
+}
+params.schema_ignore_params = params.ignore_params_list.join(",")
+params.validationSchemaIgnoreParams = params.ignore_params_list.join(",")
+
+// Apptainer settings
 singularity {
     enabled    = true
     runOptions = {
@@ -86,9 +95,3 @@ process {
         clusterOptionsCreator(task.memory, task.time, task.cpus)
     }
 }
-
-validation {
-    ignoreParams = params.ignore_params_list
-}
-params.schema_ignore_params         = params.ignore_params_list.join(",")
-params.validationSchemaIgnoreParams = params.ignore_params_list.join(",")

--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -1,91 +1,88 @@
 // Nextflow config for use with PDC at KTH
 
-def cluster = "unknown"
-
-try {
-    cluster = ['/bin/bash', '-c', 'sacctmgr show cluster -n | grep -o "^\s*[^ ]*\s*"'].execute().text.trim()
-} catch (java.io.IOException e) {
-    System.err.println("WARNING: Could not run scluster, defaulting to unknown")
-}
-
 params {
-    project = null // Naiss project allocation
+    project                      = null // Naiss project allocation
+    clusterOptions               = null
+    clusterName                  = {
+        def cluster = "unknown"
+        try {
+            cluster = ['/bin/bash', '-c', 'sacctmgr show cluster -n | grep -o "^\s*[^ ]*\s*"'].execute().text.trim()
+        }
+        catch (IOException _e) {
+            System.err.println("WARNING: Could not run sacctmgr, defaulting to unknown")
+        }
+        cluster
+    }.call()
 
-    config_profile_description = 'PDC profile.'
-    config_profile_contact = 'Pontus Freyhult (@pontus)'
-    config_profile_url = "https://www.pdc.kth.se/"
+    config_profile_description   = 'PDC profile.'
+    config_profile_contact       = 'Pontus Freyhult (@pontus)'
+    config_profile_url           = "https://www.pdc.kth.se/"
 
-    max_memory = 1790.GB
-    max_cpus = 256
-    max_time = 7.d
+    max_memory                   = 1790.GB
+    max_cpus                     = 256
+    max_time                     = 7.d
 
-    schema_ignore_params = "genomes,input_paths,cluster-options,clusterOptions,project,validationSchemaIgnoreParams"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,clusterName,validationSchemaIgnoreParams"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,clusterName,schema_ignore_params"
 }
-
-
-def containerOptionsCreator = {
-    switch(cluster) {
-        case "dardel":
-            return '-B /cfs/klemming/'
-    }
-
-    return ''
-}
-
-def clusterOptionsCreator = { mem, time, cpus ->
-    String base = "-A $params.project ${params.clusterOptions ?: ''}"
-
-    switch(cluster) {
-        case "dardel":
-            String extra = ''
-
-            if (time <= 7.d && mem <= 111.GB && cpus <= 256) {
-                extra += ' -p shared '
-            }
-            else if (time < 1.d) {
-                // Shortish
-                if (mem > 222.GB) {
-                    extra += ' -p memory,main '
-                } else {
-                    extra += ' -p main '
-                }
-            } else {
-                // Not shortish
-                if (mem > 222.GB) {
-                    extra += ' -p memory '
-                } else {
-                    extra += ' -p long '
-                }
-            }
-
-            if (!mem || mem < 6.GB) {
-                // Impose minimum memory if request is below
-                extra += ' --mem=6G '
-            }
-
-            return base+extra
-    }
-
-    return base
-}
-
 
 singularity {
-    enabled = true
-    runOptions = containerOptionsCreator()
+    enabled    = true
+    runOptions = {
+        def run_opts = []
+        if (params.clusterName == "dardel") {
+            run_opts << '-B /cfs/klemming/'
+        }
+        run_opts.minus("").join(" ")
+    }.call()
 }
 
 process {
     resourceLimits = [
         memory: 1790.GB,
         cpus: 256,
-        time: 7.d
+        time: 7.d,
     ]
     // Should we lock these to specific versions?
-    beforeScript = 'module load PDC apptainer'
+    beforeScript   = 'module load PDC apptainer'
 
-    executor = 'slurm'
-    clusterOptions = { clusterOptionsCreator(task.memory, task.time, task.cpus) }
+    executor       = 'slurm'
+    clusterOptions = {
+        def clusterOptionsCreator = { mem, time, cpus ->
+            def slurm_opts = [
+                "-A ${params.project}",
+                params.clusterOptions ?: '',
+            ]
+
+            if (params.clusterName == "dardel") {
+                if (time <= 7.d && mem <= 111.GB && cpus <= 256) {
+                    slurm_opts << '-p shared'
+                }
+                else if (time < 1.d) {
+                    // Shortish
+                    if (mem > 222.GB) {
+                        slurm_opts << '-p memory,main'
+                    }
+                    else {
+                        slurm_opts << '-p main'
+                    }
+                }
+                else {
+                    // Not shortish
+                    if (mem > 222.GB) {
+                        slurm_opts << '-p memory'
+                    }
+                    else {
+                        slurm_opts << '-p long'
+                    }
+                }
+                if (!mem || mem < 6.GB) {
+                    // Impose minimum memory if request is below
+                    slurm_opts << '--mem=6G'
+                }
+            }
+            slurm_opts.minus("").join(" ")
+        }
+        clusterOptionsCreator(task.memory, task.time, task.cpus)
+    }
 }
-

--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -22,8 +22,20 @@ params {
     max_cpus                     = 256
     max_time                     = 7.d
 
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,clusterName,validationSchemaIgnoreParams"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,clusterName,schema_ignore_params"
+    ignore_params_list           = [
+        "cluster-options",
+        "clusterOptions",
+        "clusterName",
+        "genomes",
+        "ignore_params_list",
+        "input_paths",
+        "max_cpus",
+        "max_memory",
+        "max_time",
+        "project",
+        "schema_ignore_params",
+        "validationSchemaIgnoreParams"
+        ]
 }
 
 singularity {
@@ -74,3 +86,9 @@ process {
         clusterOptionsCreator(task.memory, task.time, task.cpus)
     }
 }
+
+validation {
+    ignoreParams = params.ignore_params_list
+}
+params.schema_ignore_params         = params.ignore_params_list.join(",")
+params.validationSchemaIgnoreParams = params.ignore_params_list.join(",")

--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -31,7 +31,7 @@ singularity {
     runOptions = {
         def run_opts = []
         if (params.clusterName == "dardel") {
-            run_opts << '-B /cfs/klemming/'
+            run_opts << "-B /cfs/klemming/"
         }
         run_opts.minus("").join(" ")
     }.call()
@@ -46,35 +46,23 @@ process {
     // Should we lock these to specific versions?
     beforeScript   = 'module load PDC apptainer'
 
-    executor       = 'slurm'
+    executor       = "slurm"
     clusterOptions = {
         def clusterOptionsCreator = { mem, time, cpus ->
             def slurm_opts = [
                 "-A ${params.project}",
-                params.clusterOptions ?: '',
+                params.clusterOptions ?: "",
             ]
 
             if (params.clusterName == "dardel") {
                 if (time <= 7.d && mem <= 111.GB && cpus <= 256) {
-                    slurm_opts << '-p shared'
-                }
-                else if (time < 1.d) {
-                    // Shortish
-                    if (mem > 222.GB) {
-                        slurm_opts << '-p memory,main'
-                    }
-                    else {
-                        slurm_opts << '-p main'
-                    }
+                    slurm_opts << "-p shared"
                 }
                 else {
-                    // Not shortish
-                    if (mem > 222.GB) {
-                        slurm_opts << '-p memory'
-                    }
-                    else {
-                        slurm_opts << '-p long'
-                    }
+                    def partition = time < 1.d
+                        ? (mem > 222.GB ? 'memory,main' : 'main')
+                        : (mem > 222.GB ? 'memory' : 'long')
+                    slurm_opts << "-p ${partition}"
                 }
                 if (!mem || mem < 6.GB) {
                     // Impose minimum memory if request is below


### PR DESCRIPTION
---
name: pdc_kth
about: Update `pdc_kth` in preparation for strict syntax.
---

- Moves cluster name evaluation into parameter using a called closure.
- Uses closure for singularity run Options.
- clusterOptionsCreator moved into clusterOptions closure.
- `switch` swapped to `if` because of strict syntax.
- String concatenation changed to add to list then join. 
- Apply Nextflow code formatter.
- ~~Removes `beforeScript` because it's not called before images need to be pulled (i.e. user must do `module load PDC apptainer` themselves anyway).~~
- Shorten nested if-else with ternary.

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
