### PR TITLE
Added limits to ease pressure on scheduler

### DIFF
--- a/conf/ucl_myriad.config
+++ b/conf/ucl_myriad.config
@@ -6,6 +6,8 @@ params {
 
 executor {
     name = 'sge'
+    queueSize = 900 // Limit number of jobs sent to qsub (max is 1000)
+    submitRateLimit = '10/1s'  // Submit max 10 jobs per second. To ease pressure on scheduler.
 }
 
 process {


### PR DESCRIPTION
Just a quick update to the UCL configuration, as I was hitting scheduler limits. 
Added a rate limiter too.
