### PR TITLE
errorStrategy now correctly catches OoM and timeout for retries

### DIFF
--- a/conf/cropdiversityhpc.config
+++ b/conf/cropdiversityhpc.config
@@ -10,7 +10,7 @@ executor {
 
 process {
     scratch = true
-    errorStrategy = 'finish'
+    errorStrategy = { task.exitStatus in [137, 140] ? 'retry' : 'finish' }
     executor = 'slurm'
     queue = { task.memory <= 32.GB ? (task.time < 6.h ? task.memory <=2.GB ? 'hicpu': 'short' : task.time < 24.h ? 'medium' : 'long') : 'himem' }
     withLabel:process_gpu {


### PR DESCRIPTION
---
name: cropdiversityhpc resourcing
about: patch todays update to cropdiversityhpc
---

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [x] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [x] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->

Users reported retries on OoM were not being triggered, updated errorStrategy to catch 137 (OoM) and 140 (timeout) errors and trigger a retry