### PR TITLE
Fix error in recently updated cfc and m3c configs (final version)

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -39,19 +39,17 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
+    String co2Timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+
     // Determine timestamp suffix
-    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
-    if (timestampSuffix) {
-        timestamp = timestampSuffix
-        timestampSuffix = "_${timestampSuffix}"
-    }
+    String timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : co2Timestamp)
 
     // File parameters
     if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
-        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
-        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
-        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
+        traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"
     }
 
     // Standard parameters

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -49,7 +49,7 @@ co2footprint {
         String infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
-        summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt
+        summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"
     }
 
     // Standard parameters

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -39,20 +39,22 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
-    // Defines the timestamp model that is used as a suffix of the file
-    String co2_timestamp = params.get('trace_report_suffix') ?: this.hasProperty('trace_timestamp') ? this.getProperty('trace_timestamp') : null
-    if (co2_timestamp != null) {
-        timestamp = co2_timestamp
+    // Determine timestamp suffix
+    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
+    if (timestampSuffix) {
+        timestamp = timestampSuffix
+        timestampSuffix = "_${timestampSuffix}"
     }
 
     // File parameters
-    if (params.containsKey('outdir')) {
-        traceFile   = "${params.outdir}/pipeline_info/co2footprint_trace_${timestamp}.txt"
-        reportFile  = "${params.outdir}/pipeline_info/co2footprint_report_${timestamp}.html"
-        summaryFile  = "${params.outdir}/pipeline_info/co2footprint_summary_${timestamp}.txt"
+    if (params.outdir) {
+        def infoDir = "${params.outdir}/pipeline_info"
+        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
     }
 
     // Standard parameters
-    location          = 'DE'
-    pue               = 1.3
+    location = 'DE'
+    pue = 1.3
 }

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -47,7 +47,7 @@ co2footprint {
     }
 
     // File parameters
-    if (params.outdir) {
+    if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"

--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -46,7 +46,7 @@ co2footprint {
 
     // File parameters
     if (params.containsKey('outdir')) {
-        def infoDir = "${params.outdir}/pipeline_info"
+        String infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
         summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -28,7 +28,7 @@ params {
 }
 
 /*
- * The plugin is currently deactivated. To activate it, please add
+ * By default the nf-co2footprint plugin is not activated. To activate it, please add
  * ````
  * plugins {
  *  id 'nf-co2footprint@<VERSION>'
@@ -38,20 +38,22 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
-    // Defines the timestamp model that is used as a suffix of the file
-    String co2_timestamp = params.get('trace_report_suffix') ?: this.hasProperty('trace_timestamp') ? this.getProperty('trace_timestamp') : null
-    if (co2_timestamp != null) {
-        timestamp = co2_timestamp
+    // Determine timestamp suffix
+    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
+    if (timestampSuffix) {
+        timestamp = timestampSuffix
+        timestampSuffix = "_${timestampSuffix}"
     }
 
     // File parameters
-    if (params.containsKey('outdir')) {
-        traceFile   = "${params.outdir}/pipeline_info/co2footprint_trace_${timestamp}.txt"
-        reportFile  = "${params.outdir}/pipeline_info/co2footprint_report_${timestamp}.html"
-        summaryFile  = "${params.outdir}/pipeline_info/co2footprint_summary_${timestamp}.txt"
+    if (params.outdir) {
+        def infoDir = "${params.outdir}/pipeline_info"
+        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
     }
 
     // Standard parameters
-    location          = 'DE'
-    pue               = 1.3
+    location = 'DE'
+    pue = 1.3
 }

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -38,19 +38,17 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
+    String co2Timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+
     // Determine timestamp suffix
-    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
-    if (timestampSuffix) {
-        timestamp = timestampSuffix
-        timestampSuffix = "_${timestampSuffix}"
-    }
+    String timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : co2Timestamp)
 
     // File parameters
     if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
-        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
-        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
-        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
+        traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"
     }
 
     // Standard parameters

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -46,7 +46,7 @@ co2footprint {
     }
 
     // File parameters
-    if (params.outdir) {
+    if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"

--- a/conf/cfc_dev.config
+++ b/conf/cfc_dev.config
@@ -45,7 +45,7 @@ co2footprint {
 
     // File parameters
     if (params.containsKey('outdir')) {
-        def infoDir = "${params.outdir}/pipeline_info"
+        String infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
         summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"

--- a/conf/m3c.config
+++ b/conf/m3c.config
@@ -39,19 +39,17 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
+    String co2Timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+
     // Determine timestamp suffix
-    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
-    if (timestampSuffix) {
-        timestamp = timestampSuffix
-        timestampSuffix = "_${timestampSuffix}"
-    }
+    String timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : co2Timestamp)
 
     // File parameters
     if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
-        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
-        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
-        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
+        traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"
     }
 
     // Standard parameters

--- a/conf/m3c.config
+++ b/conf/m3c.config
@@ -47,7 +47,7 @@ co2footprint {
     }
 
     // File parameters
-    if (params.outdir) {
+    if (params.containsKey('outdir')) {
         def infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"

--- a/conf/m3c.config
+++ b/conf/m3c.config
@@ -29,7 +29,7 @@ params {
 }
 
 /*
- * The plugin is currently deactivated. To activate it, please add
+ * By default the nf-co2footprint plugin is not activated. To activate it, please add
  * ````
  * plugins {
  *  id 'nf-co2footprint@<VERSION>'
@@ -39,20 +39,22 @@ params {
  * `-plugins nf-co2footprint@<VERSION>` parameter in your nextflow call.
  */
 co2footprint {
-    // Defines the timestamp model that is used as a suffix of the file
-    String co2_timestamp = params.get('trace_report_suffix') ?: this.hasProperty('trace_timestamp') ? this.getProperty('trace_timestamp') : null
-    if (co2_timestamp != null) {
-        timestamp = co2_timestamp
+    // Determine timestamp suffix
+    def timestampSuffix = params.get('trace_report_suffix') ?: (this.hasProperty('trace_timestamp') ? this.trace_timestamp : '')
+    if (timestampSuffix) {
+        timestamp = timestampSuffix
+        timestampSuffix = "_${timestampSuffix}"
     }
 
     // File parameters
-    if (params.containsKey('outdir')) {
-        traceFile   = "${params.outdir}/pipeline_info/co2footprint_trace_${timestamp}.txt"
-        reportFile  = "${params.outdir}/pipeline_info/co2footprint_report_${timestamp}.html"
-        summaryFile  = "${params.outdir}/pipeline_info/co2footprint_summary_${timestamp}.txt"
+    if (params.outdir) {
+        def infoDir = "${params.outdir}/pipeline_info"
+        traceFile   = "${infoDir}/co2footprint_trace${timestampSuffix}.txt"
+        reportFile  = "${infoDir}/co2footprint_report${timestampSuffix}.html"
+        summaryFile = "${infoDir}/co2footprint_summary${timestampSuffix}.txt"
     }
 
     // Standard parameters
-    location          = 'DE'
-    pue               = 1.3
+    location = 'DE'
+    pue = 1.3
 }

--- a/conf/m3c.config
+++ b/conf/m3c.config
@@ -46,7 +46,7 @@ co2footprint {
 
     // File parameters
     if (params.containsKey('outdir')) {
-        def infoDir = "${params.outdir}/pipeline_info"
+        String infoDir = "${params.outdir}/pipeline_info"
         traceFile   = "${infoDir}/co2footprint_trace_${timestampSuffix}.txt"
         reportFile  = "${infoDir}/co2footprint_report_${timestampSuffix}.html"
         summaryFile = "${infoDir}/co2footprint_summary_${timestampSuffix}.txt"


### PR DESCRIPTION
---
name: Update CFC & M3 cluster config
about: Final inclusion of co2footprint parameters
---

In the previous merged PR, the `timestamp` variable was wrongly set in the output file names definition. It is now fixed.
