### PR TITLE
fix cluster definition

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -83,7 +83,7 @@ process {
 includeConfig ({
     def cluster = "unknown"
     try {
-        cluster = ['/bin/bash', '-c', "sacctmgr show cluster -P -n | cut -f1 -d'|' | grep 'miarka\\|pelle\\|rackham'"].execute().text.trim()
+        cluster = ['/bin/bash', '-c', "sacctmgr show cluster -P -n | cut -f1 -d'|' | grep 'miarka\|pelle\|rackham'"].execute().text.trim()
     }
     catch (IOException _e) {
         System.err.println("WARNING: Could not run sacctmgr, defaulting to unknown")


### PR DESCRIPTION
Remove the extra backslashes. `cluster` variable now comes back as current uppmax cluster

---
name: update uppmax.config
about: cluster variable is not returning anything at the moment
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
