### PR TITLE
UPPMAX: Handle (norma) case of no clusterOptions

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -89,7 +89,7 @@ includeConfig ({
         System.err.println("WARNING: Could not run sacctmgr, defaulting to unknown")
     }
     if (cluster == "rackham") {
-        if (params.clusterOptions.contains('-M snowy')) {
+        if (params.clusterOptions != null && params.clusterOptions.contains('-M snowy')) {
             return "uppmax/snowy.config"
         }
         else {


### PR DESCRIPTION
We try to be nice and get the right config by looking if the user requests snowy through `clusterOptions`, but didn't manage when not properly.