### PR TITLE
removing array from vsc_kul_uhasselt due to bottleneck issues

### DIFF
--- a/conf/vsc_kul_uhasselt.config
+++ b/conf/vsc_kul_uhasselt.config
@@ -23,7 +23,6 @@ process {
     stageOutMode  = "rsync"
     errorStrategy = { sleep(Math.pow(2, task.attempt ?: 1) * 200 as long); return 'retry' }
     maxRetries    = 3
-    array         = 30
 }
 
 // Specify that singularity should be used and where the cache dir will be for the images


### PR DESCRIPTION
Removing array from VSC_KUL_UHASSELT config since it can result in huge bottlenecks. 
