### PR TITLE
Update Sanger config to handle strict syntax

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -13,7 +13,7 @@ process {
     executor = 'lsf'
 
     // Processes without any explicit labels will fail to run on LSF
-    // Set low values as defaults to have a default value 
+    // Set low values as defaults to have a default value
     cpus   = 1
     memory = 6.Gb
     time   = 1.h
@@ -45,8 +45,8 @@ process {
     }
 
     withLabel: gpu {
-        clusterOptions = { 
-            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'" 
+        clusterOptions = {
+            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'"
         }
         queue = { task.time > 12.h ? 'gpu-huge' : task.time > 48.h ? 'gpu-basement' : 'gpu-normal' }
         containerOptions = {

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -7,7 +7,7 @@ params {
 
 // Queue and LSF submission options
 process {
-    executor = 'lsf'
+    executor = 'lsf'x
 
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/
@@ -66,9 +66,9 @@ includeConfig ({
         System.err.println("WARNING: Could not run lsid to determine current cluster, defaulting to farm")
     }
 
-    if (cluster == "tol22") {
+    if (clustername == "tol22") {
         return "sanger/tol22.config"
-    } else if (cluster == "farm22") {
+    } else if (clustername == "farm22") {
         return "sanger/farm22.config"
     } else {
         return "/dev/null"

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -46,7 +46,8 @@ process {
 
     withLabel: gpu {
         clusterOptions = { 
-            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'" }
+            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'" 
+        }
         queue = { task.time > 12.h ? 'gpu-huge' : task.time > 48.h ? 'gpu-basement' : 'gpu-normal' }
         containerOptions = {
             workflow.containerEngine == "singularity" ? '--containall --cleanenv --nv':

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -72,7 +72,7 @@ includeConfig ({
     try {
         clustername = ['/bin/bash', '-c', 'lsid | awk \'$0 ~ /^My cluster name is/ {print $5}\''].execute().text.trim()
     } catch (java.io.IOException e) {
-        System.err.println("WARNING: Could not run lsid to determine current cluster, defaulting to farm")
+        System.err.println("WARNING: Could not run lsid to determine current cluster, defaulting to "+clustername)
     }
 
     if (clustername == "tol22") {

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -5,6 +5,9 @@ params {
     config_profile_url = 'https://www.sanger.ac.uk'
 }
 
+// This option is unscoped
+poolSize = 4
+
 // Queue and LSF submission options
 process {
     executor = 'lsf'
@@ -56,7 +59,6 @@ process {
 executor {
     name = 'lsf'
     perJobMemLimit = true
-    poolSize = 4
     submitRateLimit = '5 sec'
     killBatchSize = 50
 }

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -7,7 +7,13 @@ params {
 
 // Queue and LSF submission options
 process {
-    executor = 'lsf'x
+    executor = 'lsf'
+
+    // Processes without any explicit labels will fail to run on LSF
+    // Set low values as defaults to have a default value 
+    cpus   = 1
+    memory = 6.Gb
+    time   = 1.h
 
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -1,12 +1,3 @@
-
-// Extract the name of the cluster to tune the parameters below
-def clustername = "farm22"
-try {
-    clustername = ['/bin/bash', '-c', 'lsid | awk \'$0 ~ /^My cluster name is/ {print $5}\''].execute().text.trim()
-} catch (java.io.IOException e) {
-    System.err.println("WARNING: Could not run lsid to determine current cluster, defaulting to farm")
-}
-
 // Profile details
 params {
     config_profile_description = "The Wellcome Sanger Institute HPC cluster profile"
@@ -14,31 +5,30 @@ params {
     config_profile_url = 'https://www.sanger.ac.uk'
 }
 
-
 // Queue and LSF submission options
 process {
     executor = 'lsf'
 
-    // Currently a single set of rules for all clusters, but we could use $clustername to apply
-    // different rules to different clusters.
+    // Currently a single set of rules for all clusters, but we could apply
+    // different rules to different clusters in their respective configs under ./sanger/
     queue = {
-        if ( task.time >= 15.day ) {
-            if ( task.memory > 680.GB ) {
+        if (task.time >= 15.day) {
+            if (task.memory > 680.GB) {
                 error "There is no queue for jobs that need >680 GB and >15 days"
             } else {
                 "basement"
             }
-        } else if ( task.memory > 720.GB ) {
+        } else if (task.memory > 720.GB) {
             "teramem"
-        } else if ( task.memory > 350.GB ) {
+        } else if (task.memory > 350.GB) {
             "hugemem"
-        } else if ( task.time > 7.day ) {
+        } else if (task.time > 7.day) {
             "basement"
-        } else if ( task.time > 2.day ) {
+        } else if (task.time > 2.day) {
             "week"
-        } else if ( task.time > 12.hour ) {
+        } else if (task.time > 12.hour) {
             "long"
-        } else if ( task.time > 1.min ) {
+        } else if (task.time > 1.min) {
             "normal"
         } else {
             "small"
@@ -46,7 +36,8 @@ process {
     }
 
     withLabel: gpu {
-        clusterOptions = { "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'" }
+        clusterOptions = { 
+            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'" }
         queue = { task.time > 12.h ? 'gpu-huge' : task.time > 48.h ? 'gpu-basement' : 'gpu-normal' }
         containerOptions = {
             workflow.containerEngine == "singularity" ? '--containall --cleanenv --nv':
@@ -54,7 +45,6 @@ process {
         }
     }
 }
-
 
 // Executor details
 executor {
@@ -65,39 +55,22 @@ executor {
     killBatchSize = 50
 }
 
+// Import cluster-specific settings from ./sanger/
+includeConfig ({
+    // Default cluster name
+    def clustername = "farm22"
 
-// Max resources
-if (clustername.startsWith("tol")) {
-    // tol cluster
-    params.max_memory = 1.4.TB
-    params.max_cpus = 64
-    params.max_time = 89280.min // 62 days
-    // As opposite to the farm settings below, we don't mount any filesystem by default.
-    // Pipelines that need to see certain filesystems have to set singularity.runOptions themselves
-
-    process {
-        resourceLimits = [
-            memory: 1.4.TB,
-            cpus: 64,
-            time: 89280.min
-        ]
+    try {
+        clustername = ['/bin/bash', '-c', 'lsid | awk \'$0 ~ /^My cluster name is/ {print $5}\''].execute().text.trim()
+    } catch (java.io.IOException e) {
+        System.err.println("WARNING: Could not run lsid to determine current cluster, defaulting to farm")
     }
 
-} else {
-    // defaults for the main farm
-    params.max_memory = 2.9.TB
-    params.max_cpus = 256
-    params.max_time = 43200.min // 30 days
-
-    process {
-        resourceLimits = [
-            memory: 2.9.TB,
-            cpus: 256,
-            time: 43200.min
-        ]
+    if (cluster == "tol22") {
+        return "sanger/tol22.config"
+    } else if (cluster == "farm22") {
+        return "sanger/farm22.config"
+    } else {
+        return "/dev/null"
     }
-
-    // Mount all filesystems by default
-    singularity.runOptions = '--bind /lustre --bind /nfs --bind /data --bind /software'
-}
-
+}.call())

--- a/conf/sanger/farm22.config
+++ b/conf/sanger/farm22.config
@@ -1,0 +1,20 @@
+// farm22 cluster at Wellcome Sanger Institute
+
+params {
+    max_memory = 2.9.TB
+    max_cpus = 256
+    max_time = 43200.min // 30 days
+}
+
+process {
+    resourceLimits = [
+        memory: 2.9.TB,
+        cpus: 256,
+        time: 43200.min
+    ]
+}
+
+singularity {
+    // Mount all filesystems by default
+    runOptions = '--bind /lustre --bind /nfs --bind /data --bind /software'
+}

--- a/conf/sanger/tol22.config
+++ b/conf/sanger/tol22.config
@@ -1,0 +1,17 @@
+// tol22 cluster at Wellcome Sanger Institute
+// As opposite to the default farm22 settings, we don't mount any filesystem by default.
+// Pipelines that need to see certain filesystems have to set singularity.runOptions themselves
+
+params {
+    max_memory = 1.4.TB
+    max_cpus = 64
+    max_time = 89280.min // 62 days
+}
+
+process {
+    resourceLimits = [
+        memory: 1.4.TB,
+        cpus: 64,
+        time: 89280.min
+    ]
+}


### PR DESCRIPTION
Updates `sanger.conf` to handle the new strict config syntax (https://nextflow.io/docs/latest/strict-syntax.html#configuration-syntax).

- moves farm22/tol22 specific config to separate subconfig files
- these config files are included using a closure which first determines which cluster you are on
- Add default values for cpus, memory, and time (otherwise processes fail if these are not set)
- moved `executor.poolSize` to `poolSize`, which is the correct name for this option

Have tested this on tol22 and it seems to work correctly.