### PR TITLE
Amend qmul_apocrita config readme for best practices

### DIFF
--- a/conf/qmul_apocrita.config
+++ b/conf/qmul_apocrita.config
@@ -1,6 +1,6 @@
 params {
 
-    config_profile_description = 'Queen Mary Universtiy of London'
+    config_profile_description = '(Unofficial) Queen Mary University of London'
     config_profile_contact     = 'Simon Murray (simon . murray AT ucl . ac . uk)'
     config_profile_url         = 'https://docs.hpc.qmul.ac.uk/'
 }

--- a/docs/qmul_apocrita.md
+++ b/docs/qmul_apocrita.md
@@ -1,5 +1,11 @@
 # nf-core/configs: Apocrita Configuration
 
+> [!WARNING]
+> This is an **unofficial** project and not officially supported by [QMUL ITS Research](https://docs.hpc.qmul.ac.uk/). Please do not approach the ITSR team for support with this config.
+
+> [!WARNING]
+> Make sure that you are fully aware of the options this config submits to Apocrita, particularly the `highmem` flag, to avoid abusing nodes on the Apocrita cluster.
+
 All nf-core pipelines have been successfully configured for use on QMUL's Apocrita cluster [Queen Mary University of London](https://docs.hpc.qmul.ac.uk/).
 
 To use, run the pipeline with `-profile qmul_apocrita`. This will download and launch the [`qmul_apocrita.config`](../conf/qmul_apocrita.config) which has been pre-configured with a setup suitable for Apocrita.
@@ -10,7 +16,7 @@ Before running the pipeline you will need to configure Apptainer and install+con
 
 ### Singularity
 
-Set the correct configuration of the cache directories, where <YOUR_ID> is replaced with you credentials which you can find by entering `whoami` into the terminal once you are logged into Apocrita. Once you have added your credentials save these lines into your `.bash_profile` file in your home directory (e.g. `/data/home/<YOUR_ID>/.bash_profile`):
+Set the correct configuration of the cache directories, where <YOUR_ID> is replaced with you credentials which you can find by entering `whoami` into the terminal once you are logged into Apocrita. Run these lines in all job scripts or interactive sessions (or create a [Private Module](https://docs.hpc.qmul.ac.uk/using/UsingModules/#private-modules) to set them):
 
 ```bash
 # Set all the Apptainer environment variables
@@ -25,19 +31,39 @@ export APPTAINER_PULLFOLDER=/data/scratch/<YOUR_ID>/.apptainer/pull
 
 ### Nextflow
 
+#### Module
+
+https://docs.hpc.qmul.ac.uk/apps/bio/nextflow/
+
+#### Conda
+
+Install Nextflow in a [Conda Environment](https://docs.hpc.qmul.ac.uk/apps/languages/miniforge/#environments) from the [Bioconda channel](https://anaconda.org/bioconda/nextflow).
+
+#### Manual installation
+
+> [!WARNING]
+> Do not pipe `curl` to `bash` as per the offical [Quick start](https://github.com/nextflow-io/nextflow?tab=readme-ov-file#quick-start) guide, follow the instructions below.
+
 Download the latest release of nextflow. _Warning:_ the `self-update` line should update to the latest version, but sometimes not, so please check which is the latest release (https://github.com/nextflow-io/nextflow/releases), you can then manually set this by entering (`NXF_VER=XX.XX.X`).
 
 ```bash
-## Download Nextflow-all
-curl -s https://get.nextflow.io | bash
-nextflow -self-update
+## Load OpenJDK module
+module load openjdk
+## Download Nextflow install script
+curl -s https://get.nextflow.io -o nextflow
+## Inspect the contents, then make it executable
+chmod +x nextflow
+## Check it runs
+./nextflow
+## Check it is up to date
+./nextflow -self-update
 NXF_VER=XX.XX.X
-chmod a+x nextflow
+```
+
+You can then move the `nextflow` executable to wherever you wish, for example:
+
+```bash
 mv nextflow ~/bin/nextflow
 ```
 
-Then make sure that your bin PATH is executable, by placing the following line in your `.bash_profile`:
-
-```bash
-export PATH=$PATH:/data/home/<YOUR_ID>/bin
-```
+Then make sure that this location is in your `$PATH`, by creating a [Private Module](https://docs.hpc.qmul.ac.uk/using/UsingModules/#private-modules), which should load the OpenJDK module as well as add the location of the executable to `$PATH`.


### PR DESCRIPTION
Since this isn't officially supported by the QMUL ITSR team (which I am a staff member of), can we please make this much clearer? Users of the cluster are approaching us for support as if this is official.

Also included are several suggested adjustments that align setup with our best practices (removing piping `curl` to `bash`, using Private Modules, not using `~/.bashrc` etc.)
