### PR TITLE
Updated resource limits for Janelia's LSF cluster

### DIFF
--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -4,9 +4,9 @@ params {
     config_profile_description   = 'IBM Platform LSF Cluster at Janelia Research Campus'
     config_profile_url           = 'https://www.janelia.org'
 
-    max_cpus                     = 48
-    max_memory                   = '768.GB'
-    max_time                     = '48.h'
+    max_cpus                     = 96
+    max_memory                   = '3840.GB'
+    max_time                     = '720.h'
 
     lsf_opts                     = ''
     lsf_queue_size               = 500
@@ -21,8 +21,8 @@ singularity {
 
 process {
     resourceLimits = [
-        memory: 768.GB,
-        cpus: 48,
+        memory: 1.TB,
+        cpus: 64,
         time: 48.h
     ]
     executor       = 'lsf'

--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -21,9 +21,9 @@ singularity {
 
 process {
     resourceLimits = [
-        memory: 1.TB,
-        cpus: 64,
-        time: 48.h
+        cpus: 96,
+        memory: 3840.GB,
+        time: 720.h
     ]
     executor       = 'lsf'
     scratch        = '/scratch/$USER'

--- a/conf/janelia.config
+++ b/conf/janelia.config
@@ -4,6 +4,7 @@ params {
     config_profile_description   = 'IBM Platform LSF Cluster at Janelia Research Campus'
     config_profile_url           = 'https://www.janelia.org'
 
+    // Old way of specifying resource limits (pre-v3.0.0)
     max_cpus                     = 96
     max_memory                   = '3840.GB'
     max_time                     = '720.h'


### PR DESCRIPTION
Janelia's compute cluster resources have been upgraded since this config was first published. 

I have updated the config with the new max and default values for cpu/memory/runtime.
