### PR TITLE
Update eddie.config

### DIFF
--- a/conf/eddie.config
+++ b/conf/eddie.config
@@ -20,7 +20,7 @@ process {
             return null
         }
         // total bytes requested, divided by slots ⇒ bytes per slot
-        def bytesPerSlot = task.memory.bytes / task.cpus
+        def bytesPerSlot = task.memory.bytes
         // convert to GB and round up to the next integer
         def gbPerSlot = Math.ceil( bytesPerSlot / (1024 * 1024 * 1024) as double )
         // emit SGE flag in “G” units


### PR DESCRIPTION
change clusterOptions, removed divide memory by num cores to work with new config of eddie by UoE Research Services. They have now changed mem_free to be respected and a max of 32GB per core.  You will now need to change base.config file per pipeline to max 12G memory

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
