### PR TITLE
Update Sanger default wall time

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -20,31 +20,27 @@ process {
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/
     queue = {
-        def out_queue = "normal"
-
         if (task.time >= 15.day) {
             if (task.memory > 680.GB) {
                 error "There is no queue for jobs that need >680 GB and >15 days"
             } else {
-                out_queue =  "basement"
+                return "basement"
             }
         } else if (task.memory > 720.GB) {
-            out_queue = "teramem"
+            return "teramem"
         } else if (task.memory > 350.GB) {
-            out_queue = "hugemem"
+            return "hugemem"
         } else if (task.time > 7.day) {
-            out_queue = "basement"
+            return "basement"
         } else if (task.time > 2.day) {
-            out_queue = "week"
+            return "week"
         } else if (task.time > 12.hour) {
-            out_queue = "long"
-        } else if (task.time > 1.min) {
-            out_queue = "normal"
+            return "long"
+        } else if (task.time > 1.min || !task.time) {
+            return "normal"
         } else {
-            out_queue = "small"
+            return "small"
         }
-
-        return out_queue
     }
 
     withLabel: gpu {

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -20,27 +20,31 @@ process {
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/
     queue = {
+        def out_queue = "normal"
+
         if (task.time >= 15.day) {
             if (task.memory > 680.GB) {
                 error "There is no queue for jobs that need >680 GB and >15 days"
             } else {
-                return "basement"
+                out_queue =  "basement"
             }
         } else if (task.memory > 720.GB) {
-            return "teramem"
+            out_queue = "teramem"
         } else if (task.memory > 350.GB) {
-            return "hugemem"
+            out_queue = "hugemem"
         } else if (task.time > 7.day) {
-            return "basement"
+            out_queue = "basement"
         } else if (task.time > 2.day) {
-            return "week"
+            out_queue = "week"
         } else if (task.time > 12.hour) {
-            return "long"
-        } else if (task.time > 1.min || !task.time) {
-            return "normal"
+            out_queue = "long"
+        } else if (task.time > 1.min) {
+            out_queue = "normal"
         } else {
-            return "small"
+            out_queue = "small"
         }
+
+        return out_queue
     }
 
     withLabel: gpu {

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -16,7 +16,6 @@ process {
     // Set low values as defaults to have a default value
     cpus   = 1
     memory = 6.Gb
-    time   = 12.h
 
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/
@@ -25,22 +24,22 @@ process {
             if (task.memory > 680.GB) {
                 error "There is no queue for jobs that need >680 GB and >15 days"
             } else {
-                "basement"
+                return "basement"
             }
         } else if (task.memory > 720.GB) {
-            "teramem"
+            return "teramem"
         } else if (task.memory > 350.GB) {
-            "hugemem"
+            return "hugemem"
         } else if (task.time > 7.day) {
-            "basement"
+            return "basement"
         } else if (task.time > 2.day) {
-            "week"
+            return "week"
         } else if (task.time > 12.hour) {
-            "long"
-        } else if (task.time > 1.min) {
-            "normal"
+            return "long"
+        } else if (task.time > 1.min || !task.time) {
+            return "normal"
         } else {
-            "small"
+            return "small"
         }
     }
 

--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -16,7 +16,7 @@ process {
     // Set low values as defaults to have a default value
     cpus   = 1
     memory = 6.Gb
-    time   = 1.h
+    time   = 12.h
 
     // Currently a single set of rules for all clusters, but we could apply
     // different rules to different clusters in their respective configs under ./sanger/


### PR DESCRIPTION
As in title. Bumps the default wall time to 12h, which is the maximum for the default queue.