### PR TITLE
Fix link to sanger.config in sanger documentation

### DIFF
--- a/docs/sanger.md
+++ b/docs/sanger.md
@@ -1,6 +1,6 @@
 # nf-core/configs: Wellcome Sanger Institute Configuration
 
-To use, run the pipeline with `-profile sanger`. This will download and launch the [`sanger.config`](../conf/sanger.config) which has been
+To use, run the pipeline with `-profile sanger`. This will download and launch the [`sanger.config`](https://github.com/nf-core/configs/blob/master/conf/sanger.config) which has been
 pre-configured with a setup suitable for the Wellcome Sanger Institute LSF cluster.
 
 ## Running the workflow on the Wellcome Sanger Institute cluster


### PR DESCRIPTION
Updated the link to the sanger.config file so it can get properly rendered on the website, to address: https://github.com/nf-core/website/issues/3702