### PR TITLE
[WIP] Update Cambridge config for current CSD3 partitions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 **/roslin** @sguizard @donalddunbar
 **/lrz_cm4** @nschan
 **/crg** @joseespinosa
+**/cambridge** @RaqManzano
 **/iris** @nikhil
 **/mahuika** @jen-reeve
 **/purdue_** @aseetharam

--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -59,11 +59,11 @@ singularity {
 process {
     resourceLimits = params.csd_selected
 
-    beforeScript = '''
+    beforeScript = """
     . /etc/profile.d/modules.sh
     module purge
-    module load rhel8/default-icl
-    '''
+    module load rhel8/default-${params.partition == 'sapphire' ? 'sar' : 'icl'}
+    """
 
     executor       = 'slurm'
     queue          = params.partition

--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -18,42 +18,38 @@ params {
     project   = null
 
     // Compatibility with nf-core schema validation across pipeline versions.
-    schema_ignore_params         = 'partition,project,max_memory,max_cpus,max_time,validationSchemaIgnoreParams'
-    validationSchemaIgnoreParams = 'partition,project,max_memory,max_cpus,max_time,schema_ignore_params,validationSchemaIgnoreParams'
+    schema_ignore_params         = 'partition,project,max_memory,max_cpus,max_time,csd_time,csd_parts,csd_selected,validationSchemaIgnoreParams'
+    validationSchemaIgnoreParams = 'partition,project,max_memory,max_cpus,max_time,csd_time,csd_parts,csd_selected,schema_ignore_params,validationSchemaIgnoreParams'
 }
 
 validation {
-    ignoreParams = ['partition', 'project', 'max_memory', 'max_cpus', 'max_time', 'schema_ignore_params', 'validationSchemaIgnoreParams']
+    ignoreParams = ['partition', 'project', 'max_memory', 'max_cpus', 'max_time', 'csd_time', 'csd_parts', 'csd_selected', 'schema_ignore_params', 'validationSchemaIgnoreParams']
 }
 
-params.max_memory = {
-    if (params.partition == 'icelake') {
-        return 256.GB  // this is a whole node
-    }
-    if (params.partition == 'icelake-himem' || params.partition == 'sapphire') {
-        return 512.GB // this is a whole node
-    }
-
-    System.err.println("ERROR: cambridge params.partition must be one of 'icelake', 'icelake-himem', or 'sapphire' (got '${params.partition}').")
-    System.exit(1)
+params.csd_time = {
+    params.project?.toUpperCase()?.contains('-SL3-') ? 12.h : 36.h
 }.call()
 
-params.max_cpus = {
-    if (params.partition == 'sapphire') {
-        return 112
-    }
-    if (params.partition == 'icelake' || params.partition == 'icelake-himem') {
-        return 76
+params.csd_parts = [
+    icelake        : [memory: 256.GB, cpus: 76, time: params.csd_time],
+    'icelake-himem': [memory: 512.GB, cpus: 76, time: params.csd_time],
+    sapphire       : [memory: 512.GB, cpus: 112, time: params.csd_time]
+]
+
+params.csd_selected = {
+    def selected = params.csd_parts[params.partition]
+
+    if (!selected) {
+        System.err.println("ERROR: cambridge params.partition must be one of 'icelake', 'icelake-himem', or 'sapphire' (got '${params.partition}').")
+        System.exit(1)
     }
 
-    System.err.println("ERROR: cambridge params.partition must be one of 'icelake', 'icelake-himem', or 'sapphire' (got '${params.partition}').")
-    System.exit(1)
+    selected
 }.call()
 
-params.max_time = {
-    def project_name = params.project?.toUpperCase()
-    return project_name?.contains('-SL3-') ? 12.h : 36.h
-}.call()
+params.max_memory = params.csd_selected.memory
+params.max_cpus   = params.csd_selected.cpus
+params.max_time   = params.csd_selected.time
 
 singularity {
     enabled    = true
@@ -61,11 +57,7 @@ singularity {
 }
 
 process {
-    resourceLimits = [
-        memory: params.max_memory,
-        cpus: params.max_cpus,
-        time: params.max_time
-    ]
+    resourceLimits = params.csd_selected
 
     executor       = 'slurm'
     queue          = params.partition

--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -59,7 +59,22 @@ singularity {
 process {
     resourceLimits = params.csd_selected
 
+    beforeScript = '''
+    . /etc/profile.d/modules.sh
+    module purge
+    module load rhel8/default-icl
+    '''
+
     executor       = 'slurm'
     queue          = params.partition
     clusterOptions = { params.project ? "--account=${params.project}" : '' }
+}
+
+executor {
+    name              = 'slurm'
+    queueSize         = 200
+    pollInterval      = '5 min'
+    queueStatInterval = '5 min'
+    submitRateLimit   = '10 sec'
+    exitReadTimeout   = '30 min'
 }

--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -1,17 +1,60 @@
-// Description is overwritten with user specific flags
+// nf-core/configs: Cambridge CSD3 cluster profile
+// Available partitions:
+//   - icelake        : 76 CPUs, 256 GB RAM
+//   - icelake-himem  : 76 CPUs, 512 GB RAM
+//   - sapphire       : 112 CPUs, 512 GB RAM
+//
+// The profile defaults to the broadly available `icelake` partition but allows
+// users to override it with `--partition`. Walltime is inferred from the SLURM
+// account name when possible: projects containing `-SL3-` use a 12 h cap,
+// otherwise the profile assumes the common SL1/SL2 36 h limit.
+
 params {
-    config_profile_description = 'Cambridge HPC cluster profile.'
-    // FIXME EmelineFavreau was the last to edit this
-    config_profile_contact     = 'Andries van Tonder (ajv37@cam.ac.uk)'
-    config_profile_url         = "https://docs.hpc.cam.ac.uk/hpc"
-    partition                  = null
-    project                    = null
-    max_memory                 = 192.GB
-    max_cpus                   = 56
-    max_time                   = 12.h
+    config_profile_description = 'Cambridge HPC CSD3 cluster profile.'
+    config_profile_contact     = 'Raquel Manzano (rm889@cam.ac.uk) and Andries van Tonder (ajv37@cam.ac.uk)'
+    config_profile_url         = 'https://docs.hpc.cam.ac.uk/hpc'
+
+    partition = 'icelake'
+    project   = null
+
+    // Compatibility with nf-core schema validation across pipeline versions.
+    schema_ignore_params         = 'partition,project,max_memory,max_cpus,max_time,validationSchemaIgnoreParams'
+    validationSchemaIgnoreParams = 'partition,project,max_memory,max_cpus,max_time,schema_ignore_params,validationSchemaIgnoreParams'
 }
 
-// Description is overwritten with user specific flags
+validation {
+    ignoreParams = ['partition', 'project', 'max_memory', 'max_cpus', 'max_time', 'schema_ignore_params', 'validationSchemaIgnoreParams']
+}
+
+params.max_memory = {
+    if (params.partition == 'icelake') {
+        return 256.GB  // this is a whole node
+    }
+    if (params.partition == 'icelake-himem' || params.partition == 'sapphire') {
+        return 512.GB // this is a whole node
+    }
+
+    System.err.println("ERROR: cambridge params.partition must be one of 'icelake', 'icelake-himem', or 'sapphire' (got '${params.partition}').")
+    System.exit(1)
+}.call()
+
+params.max_cpus = {
+    if (params.partition == 'sapphire') {
+        return 112
+    }
+    if (params.partition == 'icelake' || params.partition == 'icelake-himem') {
+        return 76
+    }
+
+    System.err.println("ERROR: cambridge params.partition must be one of 'icelake', 'icelake-himem', or 'sapphire' (got '${params.partition}').")
+    System.exit(1)
+}.call()
+
+params.max_time = {
+    def project_name = params.project?.toUpperCase()
+    return project_name?.contains('-SL3-') ? 12.h : 36.h
+}.call()
+
 singularity {
     enabled    = true
     autoMounts = true
@@ -19,10 +62,12 @@ singularity {
 
 process {
     resourceLimits = [
-        memory: 192.GB,
-        cpus: 56,
-        time: 12.h
+        memory: params.max_memory,
+        cpus: params.max_cpus,
+        time: params.max_time
     ]
+
     executor       = 'slurm'
-    clusterOptions = "-A ${params.project} -p ${params.partition}"
+    queue          = params.partition
+    clusterOptions = { params.project ? "--account=${params.project}" : '' }
 }

--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -68,6 +68,8 @@ process {
     executor       = 'slurm'
     queue          = params.partition
     clusterOptions = { params.project ? "--account=${params.project}" : '' }
+    cache          = 'lenient'
+    scratch        = true
 }
 
 executor {

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -81,9 +81,7 @@ workflows. `icelake-himem` is the better option when processes need more memory
 per CPU, for example memory-hungry tasks or jobs using only a small number of
 CPUs but requiring substantial RAM. `sapphire` provides newer Sapphire Rapids
 nodes with 112 CPUs and about 4.5 GiB RAM per CPU (512 GB per node), so it may
-be a better fit for higher-CPU jobs than `icelake`. This profile therefore keeps
-`icelake` as the default and lets users switch partitions explicitly with
-`--partition`.
+be a better fit for higher-CPU jobs than `icelake`.
 
 #### Example
 
@@ -96,9 +94,9 @@ nextflow run nf-core/sarek -profile test,cambridge --partition icelake --project
 If the project name contains `-SL3-`, the profile applies a 12 h walltime cap.
 Otherwise it assumes the standard SL1 / SL2 36 h limit.
 
-#### Running longer workflows
+#### Running Nextflow on CSD3
 
-For long runs, we recommend starting Nextflow inside a `screen` or `tmux`
+We recommend starting Nextflow inside a `screen` or `tmux`
 session so that the Nextflow manager process keeps running after you disconnect
 your SSH session.
 
@@ -117,8 +115,8 @@ screen -r nextflow
 Detaching from `tmux` leaves the workflow running in the background with
 `Ctrl-b` then `d`. For `screen`, use `Ctrl-a` then `d`.
 
-You can then logout of the HPC and reattach to the session later. 
-Before logging out, make sure to **note the node you’re on**. 
+You can then logout of the HPC and reattach to the session later.
+Before logging out, make sure to **note the node you’re on**.
 Suppose your login node was called `login-p-3`, you can later log back into this specific node as follows:
 
 ```bash
@@ -131,13 +129,18 @@ Then, you can re-attach to the `tmux`/`screen` session:
 tmux attach -t nextflow
 screen -r nextflow
 ```
-For large runs, especially with many samples, the Nextflow manager process can
-itself use substantial memory. In those cases, it is better to launch
-`nextflow run ...` inside an interactive `srun` session or submit it via
-`sbatch`, rather than running it directly on a login node.
+
+#### Large runs
+
+For large runs, for example workflows with many samples or many tasks, the
+Nextflow manager process can itself use substantial memory. In those cases, it
+is better to launch `nextflow run ...` inside an interactive `srun` session or
+submit it via `sbatch`, rather than running it directly on a login node.
+
+#### `work` directory
 
 All of the intermediate files required to run the pipeline will be stored in
-the `work/` directory. It is recommended to delete this directory after the
+the `work/` directory. It is recommended to **delete** this directory after the
 pipeline has finished successfully because it can get quite large, and all of
 the main output files will be saved in the `--outdir` directory anyway.
 

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -130,6 +130,20 @@ tmux attach -t nextflow
 screen -r nextflow
 ```
 
+#### Limit Nextflow JVM memory (recommended)
+
+If needed, you can limit the memory used by the Nextflow manager process by
+setting:
+
+```bash
+export NXF_JVM_ARGS='-Xms2g -Xmx4g'
+```
+
+This is a conservative example that should work for most runs. If the Nextflow
+manager process still runs into memory errors, increase `-Xmx` accordingly.
+This must be set **before** launching `nextflow run ...`. If you want to use
+this setting by default, you can add the export line to your `~/.bashrc`.
+
 #### Large runs
 
 For large runs, for example workflows with many samples or many tasks, the

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -67,7 +67,6 @@ export NXF_SINGULARITY_CACHEDIR=/path/to/cache/dir
 On CSD3, Singularity is available by default, so no additional module loading
 should be required.
 
-
 ### Run Nextflow
 
 Here is an example with the nf-core pipeline sarek ([read documentation here](https://nf-co.re/sarek/3.3.2)).

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -117,6 +117,20 @@ screen -r nextflow
 Detaching from `tmux` leaves the workflow running in the background with
 `Ctrl-b` then `d`. For `screen`, use `Ctrl-a` then `d`.
 
+You can then logout of the HPC and reattach to the session later. 
+Before logging out, make sure to **note the node you’re on**. 
+Suppose your login node was called `login-p-3`, you can later log back into this specific node as follows:
+
+```bash
+ssh username@login-p-3.hpc.cam.ac.uk
+```
+
+Then, you can re-attach to the `tmux`/`screen` session:
+
+```bash
+tmux attach -t nextflow
+screen -r nextflow
+```
 For large runs, especially with many samples, the Nextflow manager process can
 itself use substantial memory. In those cases, it is better to launch
 `nextflow run ...` inside an interactive `srun` session or submit it via

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -22,12 +22,12 @@ curl -s https://get.nextflow.io | bash
 # Make it executable
 chmod +x nextflow
 
-# Move it to a personal bin directory
-mkdir -p $HOME/bin
-mv nextflow $HOME/bin/
+# Move it to a personal bin directory in hpc-work
+mkdir -p $HOME/rds/hpc-work/bin
+mv nextflow $HOME/rds/hpc-work/bin/
 
 # Add that directory to your PATH if needed
-export PATH="$HOME/bin:$PATH"
+export PATH="$HOME/rds/hpc-work/bin:$PATH"
 
 # Confirm the installation
 nextflow info
@@ -61,7 +61,7 @@ automatically assigned to the current directory.
 
 ```
 # do this once per login, or add this line to .bashrc
-export NXF_SINGULARITY_CACHEDIR=/path/to/cache/dir
+export NXF_SINGULARITY_CACHEDIR=$HOME/rds/hpc-work/nxf-singularity-cache
 ```
 
 On CSD3, Singularity is available by default, so no additional module loading

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -33,6 +33,9 @@ export PATH="$HOME/bin:$PATH"
 nextflow info
 ```
 
+To make the `PATH` change persistent across sessions, add the `export PATH=...`
+line to your `~/.bashrc` or equivalent shell startup file.
+
 See the official installation guide for the latest details and Java
 requirements:
 
@@ -51,14 +54,18 @@ more conservative recommendation here.
 
 ### Set up Singularity cache
 
-Singularity allows the use of containers and will use a caching strategy. First, you might want to set the `NXF_SINGULARITY_CACHEDIR` bash environment variable, pointing at your hpc-work location. If not, it will be automatically assigned to the current directory.
+Singularity allows the use of containers and will use a caching strategy. First,
+you might want to set the `NXF_SINGULARITY_CACHEDIR` bash environment variable,
+pointing at a directory with sufficient space. If not, it will be
+automatically assigned to the current directory.
 
 ```
-# do this once per login, or add these lines to .bashrc
-export NXF_SINGULARITY_CACHEDIR=/home/<username>/singularity
+# do this once per login, or add this line to .bashrc
+export NXF_SINGULARITY_CACHEDIR=/path/to/cache/dir
 ```
 
-Once done, and ready to use Nextflow, you can check that the Singularity module is loaded by default when logging on the cluster.
+On CSD3, Singularity is available by default, so no additional module loading
+should be required.
 
 
 ### Run Nextflow
@@ -102,4 +109,4 @@ itself use substantial memory. In those cases, it is better to launch `nextflow 
 All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `--outdir` directory anyway.
 
 > NB: You will need an account to use the Cambridge HPC cluster in order to run the pipeline. If in doubt contact IT.
-> NB: Nextflow will need to submit the jobs via SLURM to the Cambridge HPC cluster and as such the commands above will have to be executed on one of the login  nodes. If in doubt contact IT.
+> NB: Nextflow will need to submit the jobs via SLURM to the Cambridge HPC cluster and as such the commands above will have to be executed on one of the login nodes. If in doubt contact IT.

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -7,48 +7,47 @@ and converted to a Singularity image or a Singularity image downloaded directly 
 
 ### Install Nextflow
 
-The latest version of Nextflow is not installed by default on the Cambridge HPC cluster CSD3. You can install it with conda:
+The latest version of Nextflow is not installed by default on the Cambridge HPC
+cluster CSD3.
+
+The recommended option is the standard Nextflow self-installing package:
 
 ```
-module load miniconda/3
+# Check that Java 17+ is available
+java -version
 
-# set up Bioconda according to the Bioconda documentation, notably setting up channels
-conda config --add channels defaults
-conda config --add channels bioconda
-conda config --add channels conda-forge
+# Download Nextflow
+curl -s https://get.nextflow.io | bash
 
-# create the environment env_nf, and install the tool nextflow
-conda create --name env_nf nextflow
+# Make it executable
+chmod +x nextflow
 
-# activate the environment containing nextflow
-conda activate env_nf
+# Move it to a personal bin directory
+mkdir -p $HOME/bin
+mv nextflow $HOME/bin/
 
-# once done with the environment, deactivate
-conda deactivate
+# Add that directory to your PATH if needed
+export PATH="$HOME/bin:$PATH"
+
+# Confirm the installation
+nextflow info
 ```
 
-Alternatively, you can install Nextflow into a directory you have write access to.
-Follow [these instructions](https://www.nextflow.io/docs/latest/getstarted.html#) from the Nextflow documentation. This alternative method requires also to update java.
+See the official installation guide for the latest details and Java
+requirements:
 
-```
-# move to desired directory on HPC
-cd /home/<username>/path/to/dir
+- [nf-core / Nextflow installation guide](https://nf-co.re/docs/usage/getting_started/installation)
 
-# get the newest version
-wget -qO- https://get.nextflow.io | bash
+If you prefer a user-managed package manager, a simple option is to install
+`micromamba` and then follow the nf-core conda-style instructions for creating
+an environment with `nextflow`:
 
-# update java version to the latest
-wget https://download.oracle.com/java/20/latest/jdk-20_linux-x64_bin.tar.gz
-tar xvfz jdk-20_linux-x64_bin.tar.gz
+- [micromamba installation guide](https://mamba.readthedocs.io/en/stable/installation/micromamba-installation.html)
+- [nf-core conda installation instructions](https://nf-co.re/docs/usage/getting_started/installation#conda-installation)
 
-# if all tools are compatible with the java version you chose, add these lines to .bashrc
-export JAVA_HOME=/home/<username>/path/to/dir/jdk-20.0.1
-export PATH=/home/<username>/path/to/dir/jdk-20.0.1/bin:$PATH
-
-# Once above is done `java --version` should return `java 20.0.1 2023-04-18`
-java --version
-
-```
+`pixi` (see more info [here](https://pixi.prefix.dev/latest/)) may also work well for personal environment management, but this profile
+does not currently provide tested `pixi` instructions, so `micromamba` is the
+more conservative recommendation here.
 
 ### Set up Singularity cache
 
@@ -56,32 +55,51 @@ Singularity allows the use of containers and will use a caching strategy. First,
 
 ```
 # do this once per login, or add these lines to .bashrc
-export NXF_SINGULARITY_CACHEDIR=/home/<username>/rds/hpc-work/path/to/cache/dir
+export NXF_SINGULARITY_CACHEDIR=/home/<username>/singularity
 ```
 
 Once done, and ready to use Nextflow, you can check that the Singularity module is loaded by default when logging on the cluster.
 
-```
-module list
-
-# If singularity is not loaded:
-module load singularity
-```
 
 ### Run Nextflow
 
 Here is an example with the nf-core pipeline sarek ([read documentation here](https://nf-co.re/sarek/3.3.2)).
-The user includes the project name and the node.
+The profile defaults to the `icelake` partition, but users can switch to
+`icelake-himem` or `sapphire` with `--partition`. The user should also provide
+their SLURM project / account with `--project`.
 
 ```
 # Launch the nf-core pipeline for a test database
 # with the Cambridge profile
-nextflow run nf-core/sarek -profile test,cambridge.config --partition "cclake" --project "NAME-SL3-CPU" --outdir nf-sarek-test
+nextflow run nf-core/sarek -profile test,cambridge --partition icelake --project NAME-SL2-CPU --outdir nf-sarek-test
 ```
 
-All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline
-has finished successfully because it can get quite large, and all of the main output files will be saved in the `results/` directory anyway.
+If the project name contains `-SL3-`, the profile applies a 12 h walltime cap.
+Otherwise it assumes the standard SL1 / SL2 36 h limit.
+
+**For long runs**, we recommend starting Nextflow inside a `screen` or `tmux`
+session so that the Nextflow manager process keeps running after you disconnect
+your SSH session.
+
+```
+# Start a tmux session
+tmux new -s nextflow
+
+# Or start a screen session
+screen -S nextflow
+
+# Re-attach later if needed
+tmux attach -t nextflow
+screen -r nextflow
+```
+
+Detaching from `tmux` leaves the workflow running in the background with
+`Ctrl-b` then `d`. For `screen`, use `Ctrl-a` then `d`.
+
+**For large runs**, especially with many samples, the Nextflow manager process can
+itself use substantial memory. In those cases, it is better to launch `nextflow run ...` inside an interactive `srun` session or submit it via `sbatch`, rather than running it directly on a login node.
+
+All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `--outdir` directory anyway.
 
 > NB: You will need an account to use the Cambridge HPC cluster in order to run the pipeline. If in doubt contact IT.
-> NB: Nextflow will need to submit the jobs via SLURM to the Cambridge HPC cluster and as such the commands above will have to be executed on one of the login
-> nodes. If in doubt contact IT.
+> NB: Nextflow will need to submit the jobs via SLURM to the Cambridge HPC cluster and as such the commands above will have to be executed on one of the login  nodes. If in doubt contact IT.

--- a/docs/cambridge.md
+++ b/docs/cambridge.md
@@ -1,14 +1,13 @@
 # nf-core/configs: Cambridge HPC Configuration
 
-All nf-core pipelines have been successfully configured for use on the Cambridge HPC cluster at the [The University of Cambridge](https://www.cam.ac.uk/).
-To use, run the pipeline with `-profile cambridge`. This will download and launch the [`cambridge.config`](../conf/cambridge.config) which has been pre-configured
-with a setup suitable for the Cambridge HPC cluster. Using this profile, either a docker image containing all of the required software will be downloaded,
-and converted to a Singularity image or a Singularity image downloaded directly before execution of the pipeline.
+All nf-core pipelines can be run on the [Cambridge HPC cluster](https://docs.hpc.cam.ac.uk/hpc/index.html) at the University of Cambridge using `-profile cambridge`.
+This will download and use the [`cambridge.config`](../conf/cambridge.config)
+institutional profile, which is configured for running pipelines on CSD3 with
+Singularity containers.
 
 ### Install Nextflow
 
-The latest version of Nextflow is not installed by default on the Cambridge HPC
-cluster CSD3.
+The latest version of Nextflow is not installed by default on CSD3.
 
 The recommended option is the standard Nextflow self-installing package:
 
@@ -48,7 +47,8 @@ an environment with `nextflow`:
 - [micromamba installation guide](https://mamba.readthedocs.io/en/stable/installation/micromamba-installation.html)
 - [nf-core conda installation instructions](https://nf-co.re/docs/usage/getting_started/installation#conda-installation)
 
-`pixi` (see more info [here](https://pixi.prefix.dev/latest/)) may also work well for personal environment management, but this profile
+`pixi` may also work well for personal environment management; see the
+[pixi documentation](https://pixi.prefix.dev/latest/). However, this profile
 does not currently provide tested `pixi` instructions, so `micromamba` is the
 more conservative recommendation here.
 
@@ -74,6 +74,19 @@ The profile defaults to the `icelake` partition, but users can switch to
 `icelake-himem` or `sapphire` with `--partition`. The user should also provide
 their SLURM project / account with `--project`.
 
+#### Choosing a partition
+
+As a rough guide, `icelake` is the default general-purpose choice for most
+workflows. `icelake-himem` is the better option when processes need more memory
+per CPU, for example memory-hungry tasks or jobs using only a small number of
+CPUs but requiring substantial RAM. `sapphire` provides newer Sapphire Rapids
+nodes with 112 CPUs and about 4.5 GiB RAM per CPU (512 GB per node), so it may
+be a better fit for higher-CPU jobs than `icelake`. This profile therefore keeps
+`icelake` as the default and lets users switch partitions explicitly with
+`--partition`.
+
+#### Example
+
 ```
 # Launch the nf-core pipeline for a test database
 # with the Cambridge profile
@@ -83,7 +96,9 @@ nextflow run nf-core/sarek -profile test,cambridge --partition icelake --project
 If the project name contains `-SL3-`, the profile applies a 12 h walltime cap.
 Otherwise it assumes the standard SL1 / SL2 36 h limit.
 
-**For long runs**, we recommend starting Nextflow inside a `screen` or `tmux`
+#### Running longer workflows
+
+For long runs, we recommend starting Nextflow inside a `screen` or `tmux`
 session so that the Nextflow manager process keeps running after you disconnect
 your SSH session.
 
@@ -102,10 +117,15 @@ screen -r nextflow
 Detaching from `tmux` leaves the workflow running in the background with
 `Ctrl-b` then `d`. For `screen`, use `Ctrl-a` then `d`.
 
-**For large runs**, especially with many samples, the Nextflow manager process can
-itself use substantial memory. In those cases, it is better to launch `nextflow run ...` inside an interactive `srun` session or submit it via `sbatch`, rather than running it directly on a login node.
+For large runs, especially with many samples, the Nextflow manager process can
+itself use substantial memory. In those cases, it is better to launch
+`nextflow run ...` inside an interactive `srun` session or submit it via
+`sbatch`, rather than running it directly on a login node.
 
-All of the intermediate files required to run the pipeline will be stored in the `work/` directory. It is recommended to delete this directory after the pipeline has finished successfully because it can get quite large, and all of the main output files will be saved in the `--outdir` directory anyway.
+All of the intermediate files required to run the pipeline will be stored in
+the `work/` directory. It is recommended to delete this directory after the
+pipeline has finished successfully because it can get quite large, and all of
+the main output files will be saved in the `--outdir` directory anyway.
 
 > NB: You will need an account to use the Cambridge HPC cluster in order to run the pipeline. If in doubt contact IT.
 > NB: Nextflow will need to submit the jobs via SLURM to the Cambridge HPC cluster and as such the commands above will have to be executed on one of the login nodes. If in doubt contact IT.


### PR DESCRIPTION
---
name: Update Cambridge CSD3 Config
about: Updating Cambridge CSD3 cluster config
---

## Summary

This PR updates the Cambridge CSD3 institutional profile to reflect the current partitions and simplifies the configuration logic based on feedback from the nf-core team.

## Changes

- update `conf/cambridge.config` with current partition limits:
  - `icelake`
  - `icelake-himem`
  - `sapphire`
- set `icelake` as the default partition
- keep `--partition` as a user override
- infer walltime limits from the SLURM account name:
  - accounts containing `-SL3-` get a `12.h` cap
  - otherwise default to `36.h` for SL1 / SL2
- add schema validation ignores for config-specific parameters
- refresh `docs/cambridge.md`:
  - update install instructions
  - document partition selection
  - explain `screen` / `tmux` usage
  - add a note recommending `srun` / `sbatch` for large runs where the Nextflow manager can become memory-heavy
- add Cambridge to `.github/CODEOWNERS`
- add Cambridge-specific module initialization and SLURM executor tuning to improve job submission stability on CSD3

## Ackowledgements

Many thanks to @pontus, @jfy133, @tdanhorn and @maxulysse  for their initial feedback in the nf-core channel.
