### PR TITLE
Fix scw that was accidentally broken

### DIFF
--- a/conf/scw.config
+++ b/conf/scw.config
@@ -15,9 +15,14 @@ params {
         System.out.println("WARNING:")
         System.out.println("WARNING: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     }.call()
-}
+
+    max_memory = 384.GB
+    max_cpus   = 20
+    max_time   = 72.h
 
 }
+
+
 singularity {
     enabled    = true
     autoMounts = true
@@ -26,11 +31,6 @@ executor {
     name      = 'slurm'
     queueSize = 10
     queue     = 'htc'
-}
-params {
-    max_memory = 384.GB
-    max_cpus   = 20
-    max_time   = 72.h
 }
 process {
     resourceLimits = [


### PR DESCRIPTION
Fix a stray (extra) } in scw config.
Also unite two params blocks to one.