### PR TITLE
Fix the --mem request not allowed error when running on Trillium nodes

### DIFF
--- a/conf/alliance_canada.config
+++ b/conf/alliance_canada.config
@@ -47,6 +47,12 @@ process {
     cpus            = 1
     time            = '1h'
 
+
+  withLabel: 'process_single' { memory = null }
+  withLabel: 'process_low'    { memory = null }
+  withLabel: 'process_medium' { memory = null }
+  withLabel: 'process_high'   { memory = null }
+
 // NOTE:
 // these resourceLimits are set to baseline CPU for each cluser
 // Currently missing are configs for GPUs


### PR DESCRIPTION
@MareikeJaniak 
@CMonnin 

Fix SBATCH ERROR
"The --mem=... request is not allowed nor necessary on Trillium; all nodes have the same amount of available memory (745 GiB) and each job get all the available memory of the node"