### PR TITLE
Fix crg config for multiplesequence align

### DIFF
--- a/conf/pipeline/multiplesequencealign/crg.config
+++ b/conf/pipeline/multiplesequencealign/crg.config
@@ -14,7 +14,7 @@ profiles {
         singularity {
             enabled = true
             envWhitelist = "CUDA_VISIBLE_DEVICES,NVIDIA_VISIBLE_DEVICES"
-            runOptions = params.contains('use_gpu') && params.use_gpu ? '--nv' : ''
+            runOptions = params.use_gpu ? '--nv' : ''
             pullTimeout = "60m"
         }
     }


### PR DESCRIPTION
The config had a syntax that is not supported in new Nextflow versions (throws error)

- [x] Your PR targets the `master` branch
