### PR TITLE
Use apptainer by default in multiplesequencealign@crg config

### DIFF
--- a/conf/pipeline/multiplesequencealign/crg.config
+++ b/conf/pipeline/multiplesequencealign/crg.config
@@ -1,7 +1,7 @@
 profiles {
     crg {
         params {
-            config_profile_contact     = 'Jose Espinosa-Carrasco (@joseespinosa)'
+            config_profile_contact     = 'Luisa Santus (@luisas)'
             config_profile_description = 'nf-core/multiplesequencealign CRG profile provided by nf-core/configs'
         }
         process {

--- a/conf/pipeline/multiplesequencealign/crg.config
+++ b/conf/pipeline/multiplesequencealign/crg.config
@@ -1,7 +1,7 @@
 profiles {
     crg {
         params {
-            config_profile_contact     = 'Luisa Santus (@luisas)'
+            config_profile_contact     = 'Jose Espinosa-Carrasco (@joseespinosa)'
             config_profile_description = 'nf-core/multiplesequencealign CRG profile provided by nf-core/configs'
         }
         process {
@@ -11,7 +11,7 @@ profiles {
                 clusterOptions = '--qos=normal --partition=gpu --gres=gpu:1g.10gb:1'
             }
         }
-        singularity {
+        apptainer {
             enabled = true
             envWhitelist = "CUDA_VISIBLE_DEVICES,NVIDIA_VISIBLE_DEVICES"
             runOptions = params.use_gpu ? '--nv' : ''


### PR DESCRIPTION
`singularity` is aliased in the CRG environment, however as the main CRG profiles sets `apptainer` it causes a conflict and thus throws an exception.

- [x] Your PR targets the `master` branch

Thanks for the previous review @maheshu and @jfy133, this time is tested :P