### PR TITLE
FEAT: Refactor CI to only test modified files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check whether profiles are all tested
-        run: python ${GITHUB_WORKSPACE}/bin/cchecker.py ${GITHUB_WORKSPACE}/nfcore_custom.config ${GITHUB_WORKSPACE}/.github/workflows/main.yml
+        run: python ${GITHUB_WORKSPACE}/bin/cchecker.py ${GITHUB_WORKSPACE}/nfcore_custom.config
 
   check_nextflow_config:
     name: Check if nextflow config runs in repository root
@@ -55,169 +55,135 @@ jobs:
           version: ${{ matrix.NXF_VER }}
       - run: nextflow lint ${GITHUB_WORKSPACE}
 
+  detect-changes:
+    runs-on: ubuntu-latest
+    name: Detect changed profiles
+    outputs:
+      tests: ${{ steps.detect.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        run: |
+          set -euo pipefail
+
+          # Determine base and head for comparison
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.event.after }}"
+          fi
+
+          # Function to build test JSON from a list of profile names
+          build_tests() {
+            local main_profiles=("$@")
+            if [ ${#main_profiles[@]} -eq 0 ]; then
+              echo '{"tests": []}'
+              return
+            fi
+            local tests=()
+            for p in "${main_profiles[@]}"; do
+              tests+=("{\"type\": \"main\", \"profile\": \"$p\"}")
+            done
+            printf '%s\n' "${tests[@]}" | jq -s -c '{tests: .}'
+          }
+
+          # On push to master, test all profiles
+          if [ "${{ github.event_name }}" == "push" ]; then
+            ALL_PROFILES=($(grep 'includeConfig' nfcore_custom.config | awk -F'/' '{print $3}' | awk -F'.' '{print $1}'))
+            TESTS=$(build_tests "${ALL_PROFILES[@]}")
+            echo "Push to master: testing all profiles"
+            echo "tests=$TESTS" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get list of changed files
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" || echo "")
+
+          if [ -z "$CHANGED" ]; then
+            echo "No changes detected."
+            echo "tests=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Core infrastructure files that should trigger a full test
+          if echo "$CHANGED" | grep -qE '^(\.github/workflows/main\.yml|nextflow\.config|nfcore_custom\.config|configtest\.nf|bin/|pipeline/[^/]+\.config)$'; then
+            ALL_PROFILES=($(grep 'includeConfig' nfcore_custom.config | awk -F'/' '{print $3}' | awk -F'.' '{print $1}'))
+            TESTS=$(build_tests "${ALL_PROFILES[@]}")
+            echo "Core files changed: testing all profiles"
+            echo "tests=$TESTS" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If only docs/README/etc changed, skip tests
+          if ! echo "$CHANGED" | grep -qvE '^(docs/|README\.md|CITATION\.cff|LICENSE|\.editorconfig|\.gitattributes|\.pre-commit-config\.yaml|\.prettierrc\.yml|\.prettierignore|\.github/(PULL_REQUEST_TEMPLATE\.md|CODEOWNERS|generate_codeowners\.sh))$'; then
+            echo "Only documentation changed, skipping tests"
+            echo "tests=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          declare -A MAIN_PROFILES
+          declare -A PIPELINE_TESTS
+
+          # Detect main profile config changes (direct files in conf/)
+          for f in $CHANGED; do
+            if [[ "$f" =~ ^conf/([^/]+)\.config$ ]]; then
+              MAIN_PROFILES["${BASH_REMATCH[1]}"]=1
+            fi
+          done
+
+          # Detect subdirectory config changes (e.g., conf/sanger/farm22.config)
+          for f in $CHANGED; do
+            if [[ "$f" =~ ^conf/([^/]+)/.+\.config$ ]] && [[ "${BASH_REMATCH[1]}" != "pipeline" ]]; then
+              MAIN_PROFILES["${BASH_REMATCH[1]}"]=1
+            fi
+          done
+
+          # Detect pipeline-specific config changes (conf/pipeline/<pipeline>/<name>.config)
+          for f in $CHANGED; do
+            if [[ "$f" =~ ^conf/pipeline/([^/]+)/(.+)\.config$ ]]; then
+              PIPELINE="${BASH_REMATCH[1]}"
+              CONFIG_FILE="${BASH_REMATCH[2]}.config"
+              if [ -f "pipeline/$PIPELINE.config" ]; then
+                while IFS= read -r profile; do
+                  if [ -n "$profile" ]; then
+                    PIPELINE_TESTS["$profile|pipeline/$PIPELINE.config"]=1
+                  fi
+                done < <(grep -B1 "conf/pipeline/$PIPELINE/$CONFIG_FILE" "pipeline/$PIPELINE.config" | grep -oP '^\s+\K\w+(?=\s*\{)')
+              fi
+            fi
+          done
+
+          # Build JSON array of test objects
+          TESTS=()
+          for profile in "${!MAIN_PROFILES[@]}"; do
+            TESTS+=("{\"type\": \"main\", \"profile\": \"$profile\"}")
+          done
+          for key in "${!PIPELINE_TESTS[@]}"; do
+            profile="${key%%|*}"
+            pipeline_config="${key#*|}"
+            TESTS+=("{\"type\": \"pipeline\", \"profile\": \"$profile\", \"pipeline_config\": \"$pipeline_config\"}")
+          done
+
+          if [ ${#TESTS[@]} -eq 0 ]; then
+            echo "No relevant test files changed"
+            echo "tests=[]" >> "$GITHUB_OUTPUT"
+          else
+            JSON=$(printf '%s\n' "${TESTS[@]}" | jq -s -c '{tests: .}')
+            echo "tests=$JSON" >> "$GITHUB_OUTPUT"
+          fi
+
   profile_test:
     runs-on: ubuntu-latest
-    name: Run ${{ matrix.profile }} profile
-    needs: test_all_profiles
+    name: "Test ${{ matrix.test.profile }}"
+    needs: [test_all_profiles, detect-changes]
     strategy:
       fail-fast: false
       matrix:
-        profile:
-          - "abims"
-          - "adcra"
-          - "alice"
-          - "alliance_canada"
-          - "apollo"
-          - "arcc"
-          - "aws_tower"
-          - "awsbatch"
-          - "azurebatch"
-          - "bi"
-          - "bigpurple"
-          - "bih"
-          - "binac2"
-          - "biohpc_gen"
-          - "biowulf"
-          - "bluebear"
-          - "cambridge"
-          - "cannon"
-          - "cbe"
-          - "ccga_dx"
-          - "ccga_cau"
-          - "ceci_dragon2"
-          - "ceci_nic5"
-          - "cedars"
-          - "ceres"
-          - "cfc"
-          - "cfc_dev"
-          - "cheaha"
-          - "computerome"
-          - "create"
-          - "crg"
-          - "crick"
-          - "cropdiversityhpc"
-          - "crukmi"
-          - "csiro_petrichor"
-          - "daisybio"
-          - "denbi_qbic"
-          - "dkfz"
-          - "ebc"
-          - "ebi_codon"
-          - "ebi_codon_slurm"
-          - "eddie"
-          - "embl_hd"
-          - "engaging"
-          - "einstein"
-          - "ethz_euler"
-          - "eva"
-          - "eva_grace"
-          - "fgcz"
-          - "fred_hutch"
-          - "fsu_draco"
-          - "fub_curta"
-          - "genotoul"
-          - "genouest"
-          - "giga"
-          - "gis"
-          - "googlebatch"
-          - "hasta"
-          - "hki_genie"
-          - "hypatia"
-          - "humantechnopole"
-          - "icr_alma"
-          - "icr_davros"
-          - "ifb_core"
-          - "imb"
-          - "ilifu"
-          - "imperial"
-          - "incliva"
-          - "ipop_up"
-          - "iris"
-          - "janelia"
-          - "jax"
-          - "jex"
-          - "unsw_katana"
-          - "ku_sund_danhead"
-          - "kaust"
-          - "ki_luria"
-          - "leicester"
-          - "lrz_cm4"
-          - "lugh"
-          - "m3c"
-          - "maestro"
-          - "mahuika"
-          - "mana"
-          - "marjorie"
-          - "lovelace"
-          - "dirac"
-          - "marvin"
-          - "mccleary"
-          - "mcw_rcc"
-          - "medair"
-          - "mjolnir_globe"
-          - "mpcdf"
-          - "mpcdf_viper"
-          - "mssm"
-          - "munin"
-          - "nci_gadi"
-          - "nu_genomics"
-          - "nygc"
-          - "nyu_hpc"
-          - "oist"
-          - "pasteur"
-          - "pawsey_nimbus"
-          - "pawsey_setonix"
-          - "pdc_kth"
-          - "phoenix"
-          - "psmn"
-          - "purdue_bell"
-          - "purdue_gautschi"
-          - "purdue_negishi"
-          - "qmul_apocrita"
-          - "rki"
-          - "rosalind"
-          - "rosalind_uge"
-          - "roslin"
-          - "sage"
-          - "sahmri"
-          - "sanger"
-          - "scw"
-          - "seadragon"
-          - "seattlechildrens"
-          - "seawulf"
-          - "seg_globe"
-          - "self_hosted_runner"
-          - "shu_bmrc"
-          - "stjude"
-          - "tes"
-          - "tigem"
-          - "tubingen_apg"
-          - "tufts"
-          - "tuos_stanage"
-          - "ucl_cscluster"
-          - "ucl_myriad"
-          - "uct_hpc"
-          - "ucd_sonic"
-          - "uge"
-          - "unibe_ibu"
-          - "unity"
-          - "unc_lccc"
-          - "unc_longleaf"
-          - "uod_hpc"
-          - "uppmax"
-          - "utd_juno"
-          - "uw_hyak_pedslabs"
-          - "uzh"
-          - "uzl_omics"
-          - "vai"
-          - "vsc_calcua"
-          - "vsc_kul_uhasselt"
-          - "vsc_ugent"
-          - "wehi"
-          - "wustl_htcf"
-          - "xanadu"
-          - "york_viking"
-
+        test: ${{ fromJson(needs.detect-changes.outputs.tests).tests }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4
@@ -228,8 +194,14 @@ jobs:
         uses: nf-core/setup-nextflow@v2
         with:
           version: "latest-everything"
-      - name: Check ${{ matrix.profile }} profile
+      - name: Check ${{ matrix.test.profile }} profile
+        if: matrix.test.type == 'main'
         env:
           SCRATCH: "~"
           NXF_GLOBAL_CONFIG: awsbatch.config
-        run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf -profile ${{ matrix.profile }}
+        run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf -profile ${{ matrix.test.profile }}
+      - name: Check ${{ matrix.test.profile }} profile for ${{ matrix.test.pipeline_config }}
+        if: matrix.test.type == 'pipeline'
+        env:
+          SCRATCH: "~"
+        run: nextflow run ${GITHUB_WORKSPACE}/configtest.nf -profile ${{ matrix.test.profile }} -c ${{ matrix.test.pipeline_config }} --custom_config_base ${GITHUB_WORKSPACE}

--- a/bin/cchecker.py
+++ b/bin/cchecker.py
@@ -9,7 +9,8 @@
 import sys
 import argparse
 import re
-import yaml
+import os
+import glob
 
 ############################################
 ############################################
@@ -17,17 +18,12 @@ import yaml
 ############################################
 ############################################
 
-Description = (
-    "Double check custom config file and github actions file to test all cases"
-)
-Epilog = (
-    """Example usage: python cchecker.py <nfcore_custom.config> <github_actions_file>"""
-)
+Description = "Check consistency between custom config files and the registry"
+Epilog = """Example usage: python cchecker.py <nfcore_custom.config>"""
 
 argParser = argparse.ArgumentParser(description=Description, epilog=Epilog)
 ## REQUIRED PARAMETERS
 argParser.add_argument("CUSTOM_CONFIG", help="Input nfcore_custom.config.")
-argParser.add_argument("GITHUB_CONFIG", help="Input Github Actions YAML")
 
 args = argParser.parse_args()
 
@@ -38,43 +34,123 @@ args = argParser.parse_args()
 ############################################
 
 
-def check_config(Config, Github):
+def check_config(Config):
+    """Check that all profiles in nfcore_custom.config have a matching config file."""
     regex = "includeConfig*"
+    missing_files = []
 
-    ## CHECK Config First
-    config_profiles = set()
     with open(Config, "r") as cfg:
+        config_dir = os.path.dirname(Config)
         for line in cfg:
             if re.search(regex, line):
-                hit = line.split("/")[2].split(".")[0]
-                config_profiles.add(hit.strip())
+                # Extract the profile name from: includeConfig "${params.custom_config_base}/conf/<name>.config"
+                profile = line.split("/")[2].split(".")[0]
+                config_path = os.path.join(config_dir, "conf", f"{profile}.config")
+                if not os.path.exists(config_path):
+                    missing_files.append(profile)
 
-    ### Check Github Config now
-    tests = set()
-    ### Ignore these profiles
-    ignore_me = ["czbiohub_aws"]
-    tests.update(ignore_me)
-    # parse yaml GitHub actions file
-    try:
-        with open(Github, "r") as ghfile:
-            wf = yaml.safe_load(ghfile)
-            profile_list = wf["jobs"]["profile_test"]["strategy"]["matrix"]["profile"]
-    except Exception as e:
-        print("Could not parse yaml file: {}, {}".format(Github, e))
-        sys.exit(1)
-    # Add profiles to test
-    for profile in profile_list:
-        tests.add(profile.strip())
-
-    ###Check if sets are equal
-    try:
-        assert tests == config_profiles
-    except AssertionError:
+    if missing_files:
         print(
-            "Tests don't seem to test these profiles properly. Please check whether you added the profile to the Github Actions testing YAML.\n"
+            f"ERROR: The following profiles in {Config} are missing their config files:\n"
         )
-        print(config_profiles.symmetric_difference(tests))
+        for p in missing_files:
+            print(f"  - {p}")
+        sys.exit(1)
+    else:
+        print("All profiles in nfcore_custom.config have matching config files.")
+
+
+def check_config_files(Config):
+    """Check that all config files in conf/ are referenced in nfcore_custom.config."""
+    custom_config_dir = os.path.dirname(Config)
+    conf_dir = os.path.join(custom_config_dir, "conf")
+
+    # Known config files that are not registered as profiles
+    ignore = {"azurebatchdev", "wcm"}
+
+    # Get all referenced profiles from nfcore_custom.config
+    referenced = set()
+    with open(Config, "r") as cfg:
+        for line in cfg:
+            if re.search(r"includeConfig\s*\"", line):
+                profile = line.split("/")[2].split(".")[0]
+                referenced.add(profile)
+
+    # Check all .config files in conf/ (excluding pipeline/ subdirectory)
+    orphaned = []
+    for config_file in glob.glob(os.path.join(conf_dir, "*.config")):
+        profile = os.path.splitext(os.path.basename(config_file))[0]
+        if profile not in referenced and profile not in ignore:
+            orphaned.append(profile)
+
+    if orphaned:
+        print(
+            f"ERROR: The following config files in {conf_dir} are not referenced in {Config}:\n"
+        )
+        for p in orphaned:
+            print(f"  - {p}")
+        sys.exit(1)
+    else:
+        print("All config files in conf/ are referenced in nfcore_custom.config.")
+
+
+def check_pipeline_configs(Config):
+    """Check that pipeline-specific configs have matching entries in pipeline/*.config."""
+    custom_config_dir = os.path.dirname(Config)
+    pipeline_conf_dir = os.path.join(custom_config_dir, "conf", "pipeline")
+    pipeline_dir = os.path.join(custom_config_dir, "pipeline")
+
+    # Known pipeline config files that exist but are not yet referenced
+    ignore = {
+        "methylseq/ku_sund_danhead",
+        "rnaseq/kaust",
+        "rnaseq/ku_sund_dangpu",
+        "seqinspector/hasta",
+    }
+
+    if not os.path.exists(pipeline_conf_dir):
+        return
+
+    orphaned_configs = []
+
+    for pipeline_name in os.listdir(pipeline_conf_dir):
+        pipeline_config_path = os.path.join(pipeline_dir, f"{pipeline_name}.config")
+        pipeline_dir_path = os.path.join(pipeline_conf_dir, pipeline_name)
+
+        if not os.path.isdir(pipeline_dir_path):
+            continue
+
+        if not os.path.exists(pipeline_config_path):
+            print(
+                f"WARNING: Pipeline config directory 'conf/pipeline/{pipeline_name}' exists but no 'pipeline/{pipeline_name}.config' file found."
+            )
+            continue
+
+        # Get all referenced config files from pipeline config
+        referenced = set()
+        with open(pipeline_config_path, "r") as f:
+            for line in f:
+                if re.search(r"includeConfig\s*\"", line):
+                    match = re.search(r"conf/pipeline/[^/]+/(.+)\.config\"", line)
+                    if match:
+                        referenced.add(match.group(1))
+
+        # Check all config files in the pipeline directory
+        for config_file in glob.glob(os.path.join(pipeline_dir_path, "*.config")):
+            profile = os.path.splitext(os.path.basename(config_file))[0]
+            key = f"{pipeline_name}/{profile}"
+            if profile not in referenced and key not in ignore:
+                orphaned_configs.append(key)
+
+    if orphaned_configs:
+        print(
+            "ERROR: The following pipeline config files are not referenced in their pipeline config:\n"
+        )
+        for p in orphaned_configs:
+            print(f"  - {p}")
         sys.exit(1)
 
 
-check_config(Config=args.CUSTOM_CONFIG, Github=args.GITHUB_CONFIG)
+check_config(Config=args.CUSTOM_CONFIG)
+check_config_files(Config=args.CUSTOM_CONFIG)
+check_pipeline_configs(Config=args.CUSTOM_CONFIG)


### PR DESCRIPTION
## Description

Replace the hardcoded 154-profile test matrix with a dynamic `detect-changes` job that only tests profiles affected by the PR.

Inspired by nf-core/modules' approach with `detect-nf-test-changes`.

## Changes

### `.github/workflows/main.yml`
- **New `detect-changes` job**: Uses `git diff` with `fetch-depth: 0` between base and head to determine which files changed, then builds a JSON test matrix dynamically
- **Dynamic `profile_test` matrix**: Instead of a hardcoded list of 154 profiles, the matrix is built from `fromJson(needs.detect-changes.outputs.tests)`
- **Smart test selection**:
  - Push to master → test all profiles
  - Core infrastructure (main.yml, nextflow.config, nfcore_custom.config, configtest.nf, bin/) → test all profiles
  - `conf/<name>.config` changes → test only that profile
  - `conf/sanger/farm22.config` or `conf/uppmax/rackham.config` changes → test the parent profile
  - `conf/pipeline/<pipeline>/<name>.config` changes → test the matching pipeline profiles with `-c pipeline/<pipeline>.config --custom_config_base ${GITHUB_WORKSPACE}`
  - Only docs changed → skip tests entirely
- **Pipeline tests**: New `type: pipeline` test steps that run `nextflow run configtest.nf -profile <name> -c pipeline/<pipeline>.config --custom_config_base ${GITHUB_WORKSPACE}`

### `bin/cchecker.py`
- Removed GitHub Actions matrix validation (no longer a hardcoded matrix)
- Now validates internal consistency:
  - All profiles in `nfcore_custom.config` have config files in `conf/`
  - All config files in `conf/` are registered in `nfcore_custom.config`
  - All pipeline-specific configs are referenced in `pipeline/<pipeline>.config`

## Testing

This PR should be tested by creating a PR that modifies a single config file and verifying only that profile's test runs.