### PR TITLE
Updated Sanger config for the new LSF queues

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -16,43 +16,6 @@ process {
     // Set low values as defaults to have a default value
     cpus   = 1
     memory = 6.Gb
-
-    // Currently a single set of rules for all clusters, but we could apply
-    // different rules to different clusters in their respective configs under ./sanger/
-    queue = {
-        if (task.time >= 15.day) {
-            if (task.memory > 680.GB) {
-                error "There is no queue for jobs that need >680 GB and >15 days"
-            } else {
-                return "basement"
-            }
-        } else if (task.memory > 720.GB) {
-            return "teramem"
-        } else if (task.memory > 350.GB) {
-            return "hugemem"
-        } else if (task.time > 7.day) {
-            return "basement"
-        } else if (task.time > 2.day) {
-            return "week"
-        } else if (task.time > 12.hour) {
-            return "long"
-        } else if (task.time > 1.min || !task.time) {
-            return "normal"
-        } else {
-            return "small"
-        }
-    }
-
-    withLabel: gpu {
-        clusterOptions = {
-            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'"
-        }
-        queue = { task.time > 12.h ? 'gpu-huge' : task.time > 48.h ? 'gpu-basement' : 'gpu-normal' }
-        containerOptions = {
-            workflow.containerEngine == "singularity" ? '--containall --cleanenv --nv':
-            ( workflow.containerEngine == "docker" ? '--gpus all': null )
-        }
-    }
 }
 
 // Executor details

--- a/conf/sanger/farm22.config
+++ b/conf/sanger/farm22.config
@@ -1,17 +1,42 @@
 // farm22 cluster at Wellcome Sanger Institute
 
 params {
-    max_memory = 2.9.TB
+    max_memory = 3.8.TB
     max_cpus = 256
     max_time = 43200.min // 30 days
 }
 
 process {
     resourceLimits = [
-        memory: 2.9.TB,
+        memory: 3.8.TB,
         cpus: 256,
         time: 43200.min
     ]
+
+    queue = {
+        if (task.memory > 350.GB) {
+            return "hugemem"
+        } else if (task.time > 7.day) {
+            return "basement"
+        } else if (task.time > 2.day) {
+            return "week"
+        } else if (task.time > 12.hour) {
+            return "long"
+        } else {
+            return "normal"
+        }
+    }
+
+    withLabel: gpu {
+        clusterOptions = {
+            "-M "+task.memory.toMega()+" -R 'select[mem>="+task.memory.toMega()+"] rusage[mem="+task.memory.toMega()+"] span[ptile=1]' -gpu 'num=1:j_exclusive=yes'"
+        }
+        queue = { task.time > 7.d ? 'gpu-basement' : 'gpu' }
+        containerOptions = {
+            workflow.containerEngine == "singularity" ? '--containall --cleanenv --nv':
+            ( workflow.containerEngine == "docker" ? '--gpus all': null )
+        }
+    }
 }
 
 singularity {

--- a/conf/sanger/tol22.config
+++ b/conf/sanger/tol22.config
@@ -1,6 +1,7 @@
 // tol22 cluster at Wellcome Sanger Institute
 // As opposite to the default farm22 settings, we don't mount any filesystem by default.
 // Pipelines that need to see certain filesystems have to set singularity.runOptions themselves
+// The queues also slightly differ.
 
 params {
     max_memory = 1.4.TB
@@ -14,4 +15,28 @@ process {
         cpus: 64,
         time: 89280.min
     ]
+
+    queue = {
+        if (task.time >= 15.day) {
+            if (task.memory > 680.GB) {
+                error "There is no queue for jobs that need >680 GB and >15 days"
+            } else {
+                return "basement"
+            }
+        } else if (task.memory > 720.GB) {
+            return "teramem"
+        } else if (task.memory > 350.GB) {
+            return "hugemem"
+        } else if (task.time > 7.day) {
+            return "basement"
+        } else if (task.time > 2.day) {
+            return "week"
+        } else if (task.time > 12.hour) {
+            return "long"
+        } else if (task.time > 1.min || !task.time) {
+            return "normal"
+        } else {
+            return "small"
+        }
+    }
 }


### PR DESCRIPTION
The LSF queues at the Sanger are changing. The `farm22` and `tol22` now have different queue configurations, so I've moved the `queue` settings to the farm-specific files.