### PR TITLE
Workaround for FCS-GX in Tree of Life pipelines at the Sanger

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -45,3 +45,16 @@ includeConfig ({
         return "/dev/null"
     }
 }.call())
+
+
+// HPC optimisations and workarounds
+process {
+
+    // From @muffato and @DLBPointon
+    // We're unable to make this software run through Singularity. Enabling
+    // use of the bare-metal installation through a module as a workaround.
+    withName: 'SANGERTOL.*:FCSGX_RUNGX' {
+        module = "fcs-gx/farm/0.5.5"
+        container = null
+    }
+}


### PR DESCRIPTION
We're unable to make FCS-GX run through Singularity. Our workaround is to use a bare-metal installation that is provided as a module.
Conda works too but cannot be considered a fallback for singularity because the singularity profile does `conda.enabled = false`

The `withName` rule is restricted to https://github.com/sanger-tol pipelines, which we control.

---
name: New Config
about: A new cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [ ] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
