### PR TITLE
Add verily_workbench profile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@
 **/mahuika** @jen-reeve
 **/mcw_rcc** @semenko
 **/purdue_** @aseetharam
+**/verily_workbench** @samhornstein

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,7 @@ jobs:
           - "uzh"
           - "uzl_omics"
           - "vai"
+          - "verily_workbench"
           - "vsc_calcua"
           - "vsc_kul_uhasselt"
           - "vsc_ugent"

--- a/conf/verily_workbench.config
+++ b/conf/verily_workbench.config
@@ -1,0 +1,43 @@
+// Verily Workbench (Google Cloud Batch) nf-core configuration profile
+params {
+    config_profile_description = 'Verily Workbench (Google Cloud Batch)'
+    config_profile_contact     = 'Sam Hornstein (@samhornstein), Verily Workbench Support (workbench-support@verily.com)'
+    config_profile_url         = 'https://support.workbench.verily.com/docs/guides/workflows/nextflow/'
+
+    //project
+    project_id                 = null
+    location                   = 'us-central1'
+    workdir_bucket             = null
+
+    //compute
+    use_spot                   = false
+    boot_disk                  = '100 GB'
+    workers_service_account    = null
+
+    //networking
+    use_private_ip             = true
+    // Workbench provisions a fixed VPC layout in every workspace; override only
+    // if your workspace differs. Custom VPC format: 'global/networks/[custom_VPC]'
+    custom_vpc                 = 'global/networks/network'
+    // Custom subnet format: 'regions/[GCP_Region]/subnetworks/[custom_subnet]'.
+    // Defaults to the Workbench subnet for `location` when left null.
+    custom_subnet              = null
+}
+
+workDir = params.workdir_bucket
+
+process {
+    executor = 'google-batch'
+}
+
+google {
+    location                  = params.location
+    project                   = params.project_id ?: System.getenv('GOOGLE_CLOUD_PROJECT')
+    batch.serviceAccountEmail = params.workers_service_account ?: System.getenv('GOOGLE_SERVICE_ACCOUNT_EMAIL')
+    batch.network             = params.custom_vpc
+    batch.subnetwork          = params.custom_subnet ?: "regions/${params.location}/subnetworks/subnetwork"
+    batch.usePrivateAddress   = params.use_private_ip
+    batch.spot                = params.use_spot
+    batch.maxSpotAttempts     = 5
+    batch.bootDiskSize        = params.boot_disk
+}

--- a/conf/verily_workbench.config
+++ b/conf/verily_workbench.config
@@ -24,6 +24,21 @@ params {
     custom_subnet              = null
 }
 
+// Stop nf-schema from flagging the profile's parameters as unrecognized.
+validation {
+    ignoreParams = [
+        'project_id',
+        'location',
+        'workdir_bucket',
+        'use_spot',
+        'boot_disk',
+        'workers_service_account',
+        'use_private_ip',
+        'custom_vpc',
+        'custom_subnet',
+    ]
+}
+
 workDir = params.workdir_bucket
 
 process {

--- a/docs/verily_workbench.md
+++ b/docs/verily_workbench.md
@@ -1,0 +1,61 @@
+# nf-core/configs: Verily Workbench Configuration
+
+Run nf-core pipelines on [Verily Workbench](https://workbench.verily.com/) using the Google Cloud Batch executor, by adding `-profile verily_workbench` to your run command.
+
+The profile reads the project and worker service account from the environment variables that Workbench injects into every job (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`), and targets the VPC network layout that Workbench provisions in each workspace. In most cases you only need to set a work directory and `--outdir`.
+
+For a step-by-step walkthrough of running Nextflow on Verily Workbench, see the [hello-nf-on-vwb tutorial](https://github.com/verily-src/workbench-examples/tree/main/nextflow/hello-nf-on-vwb).
+
+## Usage
+
+Launch a pipeline from a Workbench workflow job with `verily_workbench` in the profiles field (compose it with `test` to run the bundled test dataset):
+
+```
+-profile test,verily_workbench
+```
+
+Because Batch has no local launch directory, both the work directory and `--outdir` must be Cloud Storage locations. Supply `--outdir` as a `gs://` path (e.g. via the job's parameters file); it is a per-run value and is intentionally not set by this profile.
+
+## Required Parameters
+
+### `--workdir_bucket`
+
+Cloud Storage location for the Nextflow work directory, e.g. `gs://my-workspace-bucket/work`. On Workbench this is typically set for you from the job's output bucket.
+
+## Optional Parameters
+
+### `--project_id`
+
+Google Cloud project in which Batch resources are created. Defaults to the `GOOGLE_CLOUD_PROJECT` environment variable set by Workbench.
+
+### `--workers_service_account`
+
+Service account used by the Batch worker VMs. Defaults to the `GOOGLE_SERVICE_ACCOUNT_EMAIL` environment variable set by Workbench.
+
+### `--location`
+
+Region where Batch provisions compute. Defaults to `us-central1`.
+
+### `--use_spot`
+
+Use Spot VMs when `true` (with up to 5 attempts). Defaults to `false`.
+
+### `--boot_disk`
+
+Boot disk size for worker VMs. Defaults to `100 GB`.
+
+### `--use_private_ip`
+
+Run worker VMs without external IP addresses. Defaults to `true`, matching the Workbench workspace network. When `true`, a Cloud NAT on the VPC is required for workers to reach the internet (e.g. to pull container images).
+
+### `--custom_vpc`
+
+VPC network for worker VMs, in the format `global/networks/[custom_VPC]`. Defaults to the network Workbench provisions in every workspace; override only if yours differs.
+
+### `--custom_subnet`
+
+Subnetwork for worker VMs, in the format `regions/[GCP_Region]/subnetworks/[custom_subnet]`. Defaults to the Workbench subnet for the selected `location` when left unset.
+
+## Networking note
+
+Worker VMs run without external IP addresses by default (`--use_private_ip`), so they reach the internet only through the Cloud NAT on the workspace VPC. Pulling large or numerous remote inputs directly from public URLs (for example a pipeline's default test-data on GitHub) can be throttled. For reliable runs, stage inputs and reference files in Cloud Storage and point the pipeline parameters at `gs://` paths.

--- a/nfcore_custom.config
+++ b/nfcore_custom.config
@@ -457,6 +457,9 @@ profiles {
     vai {
         includeConfig "${params.custom_config_base}/conf/vai.config"
     }
+    verily_workbench {
+        includeConfig "${params.custom_config_base}/conf/verily_workbench.config"
+    }
     vsc_calcua {
         includeConfig "${params.custom_config_base}/conf/vsc_calcua.config"
     }


### PR DESCRIPTION
## Add `verily_workbench` profile

Adds an institutional profile for running nf-core pipelines on [Verily Workbench](https://workbench.verily.com/) via the Google Cloud Batch executor.

The profile is a Workbench-specialized sibling of `googlebatch`: it reads project and worker service account from the environment variables Workbench injects into each job (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`) and defaults to the VPC network layout Workbench provisions in every workspace, while keeping all values overridable as params.

Tested end-to-end on Google Cloud Batch from a Verily Workbench workspace with `nf-core/demo` and `nf-core/rnaseq` (`-profile test,verily_workbench`); both completed successfully.

### Steps for adding a new config profile

- [x] Add your custom config file to the `conf/` directory
- [x] Add your documentation file to the `docs/` directory
- [x] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [x] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [x] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS`
