### PR TITLE
Fix apptainer access to node-local scratch

### DIFF
--- a/conf/dkfz.config
+++ b/conf/dkfz.config
@@ -76,7 +76,10 @@ process {
     }
 
     // Bind /omics into every container; add --nv for GPU tasks.
-    containerOptions = { task.accelerator ? '--bind /omics --nv' : '--bind /omics' }
+    containerOptions = {
+        def binds = '--bind /omics --bind /local'
+        task.accelerator ? "${binds} --nv" : binds
+    }
 }
 
 executor {


### PR DESCRIPTION
Apptainer containers currently only bind `/omics`. Minor change to bind `/local` globally in the profile so that LSF-provided local scratch remains accessible to all containerized tasks.