### PR TITLE
Update sanger.config

### DIFF
--- a/conf/sanger.config
+++ b/conf/sanger.config
@@ -46,15 +46,3 @@ includeConfig ({
     }
 }.call())
 
-
-// HPC optimisations and workarounds
-process {
-
-    // From @muffato and @DLBPointon
-    // We're unable to make this software run through Singularity. Enabling
-    // use of the bare-metal installation through a module as a workaround.
-    withName: 'SANGERTOL.*:FCSGX_RUNGX' {
-        module = "fcs-gx/farm/0.5.5"
-        container = null
-    }
-}


### PR DESCRIPTION
Removal of the FCSGX_RUNGX config addition

We forgot this meant people would get warnings about tools they arn't using. Instead we'll patch the profile locally for effected pipelines.