### PR TITLE
Add GPU configuration to Pelle (UPPMAX) profile

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -14,8 +14,8 @@ params {
     config_profile_url           = 'https://www.uppmax.uu.se/'
     project                      = null
     clusterOptions               = null
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,gpu_partition"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,gpu_partition,schema_ignore_params"
     save_reference               = true
     // Defaults set for Bianca - other clusters set using includeConfig below
     max_memory                   = 500.GB
@@ -29,6 +29,7 @@ params {
         "clusterName",
         "genomes",
         "gpu_gres",
+        "gpu_partition",
         "ignore_params_list",
         "input_paths",
         "max_cpus",

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -14,8 +14,8 @@ params {
     config_profile_url           = 'https://www.uppmax.uu.se/'
     project                      = null
     clusterOptions               = null
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,gpu_partition"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,gpu_partition,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,schema_ignore_params"
     save_reference               = true
     // Defaults set for Bianca - other clusters set using includeConfig below
     max_memory                   = 500.GB
@@ -29,7 +29,6 @@ params {
         "clusterName",
         "genomes",
         "gpu_gres",
-        "gpu_partition",
         "ignore_params_list",
         "input_paths",
         "max_cpus",

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -14,8 +14,8 @@ params {
     config_profile_url           = 'https://www.uppmax.uu.se/'
     project                      = null
     clusterOptions               = null
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,schema_ignore_params"
     save_reference               = true
     // Defaults set for Bianca - other clusters set using includeConfig below
     max_memory                   = 500.GB
@@ -28,6 +28,7 @@ params {
         "clusterOptions",
         "clusterName",
         "genomes",
+        "gpu_gres",
         "ignore_params_list",
         "input_paths",
         "max_cpus",

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -12,6 +12,7 @@ params {
 
 // Hardware: https://docs.uppmax.uu.se/hardware/clusters/pelle/#pellemaja-hardware
 // Resource limits: https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#the-pelle-partition
+// GPU modules: https://nf-co.re/docs/developing/components/gpu-modules
 process {
     resourceLimits = [
         cpus: 96,

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -22,20 +22,12 @@ process {
         [
             "-A ${params.project}",
             params.clusterOptions ?: "",
-            task.memory > 768.GB
-                ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}"
-                : "",
+            task.accelerator
+                ? "-p ${params.gpu_partition} --gpus=${params.gpu_gres}"
+                : task.memory > 768.GB
+                    ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}"
+                    : "",
         ].minus("").join(" ")
-    }
-    withLabel: process_gpu {
-        clusterOptions = {
-            [
-                "-A ${params.project}",
-                params.clusterOptions ?: "",
-                "-p ${params.gpu_partition}",
-                "--gpus=${params.gpu_gres}"
-            ].minus("").join(" ")
-        }
     }
 }
 

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -4,7 +4,6 @@
 params {
     config_profile_description = 'UPPMAX (Pelle) cluster profile provided by nf-core/configs.'
     gpu_gres                   = 'l40s:1' // GPU generic resources: https://slurm.schedmd.com/gres.html
-    gpu_partition              = 'gpu'
     max_cpus                   = 96
     max_memory                 = 3.TB
     max_time                   = 10.d
@@ -12,7 +11,6 @@ params {
 
 // Hardware: https://docs.uppmax.uu.se/hardware/clusters/pelle/#pellemaja-hardware
 // Resource limits: https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#the-pelle-partition
-// GPU modules: https://nf-co.re/docs/developing/components/gpu-modules
 process {
     resourceLimits = [
         cpus: 96,
@@ -20,11 +18,25 @@ process {
         time: 10.d,
     ]
     clusterOptions = {
+        // https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#partitions-on-pelle
+        def gpu_partition = [
+            'l40s': 'gpu',
+            'h100': 'gpu',
+            't4': 'haswell'
+        ]
+        def gpu_parts = params.gpu_gres.tokenize(':')
+        def gpu_type  = (gpu_parts.size() > 1) ? gpu_parts.head() : 'l40s'
+        if (task.accelerator && !gpu_partition.containsKey(gpu_type)) {
+            throw new IllegalArgumentException(
+                "gpu_gres '${params.gpu_gres}' specifies unknown GPU type '${gpu_type}'. Valid types: ${gpu_partition.keySet().sort().join(', ')}"
+            )
+        }
+
         [
             "-A ${params.project}",
             params.clusterOptions ?: "",
-            task.accelerator
-                ? "-p ${params.gpu_partition} --gpus=${params.gpu_gres}"
+            task.accelerator // Follows implementation pattern described by https://nf-co.re/docs/developing/components/gpu-modules
+                ? "-p ${gpu_partition[gpu_type]} --gpus=${params.gpu_gres}"
                 : task.memory > 768.GB
                     ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}"
                     : "",

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -3,11 +3,11 @@
 
 params {
     config_profile_description = 'UPPMAX (Pelle) cluster profile provided by nf-core/configs.'
+    gpu_gres                   = 'l40s:1' // GPU generic resources: https://slurm.schedmd.com/gres.html
+    gpu_partition              = 'gpu'
     max_cpus                   = 96
     max_memory                 = 3.TB
     max_time                   = 10.d
-    gpu_partition              = 'gpu'
-    gpu_gres                   = null
 }
 
 // Hardware: https://docs.uppmax.uu.se/hardware/clusters/pelle/#pellemaja-hardware
@@ -33,7 +33,7 @@ process {
                 "-A ${params.project}",
                 params.clusterOptions ?: "",
                 "-p ${params.gpu_partition}",
-                params.gpu_gres ? "--gpus=${params.gpu_gres}" : '--gpus=l40s:1'
+                "--gpus=${params.gpu_gres}"
             ].minus("").join(" ")
         }
     }

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -6,6 +6,8 @@ params {
     max_cpus                   = 96
     max_memory                 = 3.TB
     max_time                   = 10.d
+    gpu_partition              = 'gpu'
+    gpu_gres                   = null
 }
 
 // Hardware: https://docs.uppmax.uu.se/hardware/clusters/pelle/#pellemaja-hardware
@@ -24,6 +26,16 @@ process {
                 ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}"
                 : "",
         ].minus("").join(" ")
+    }
+    withLabel: process_gpu {
+        clusterOptions = {
+            [
+                "-A ${params.project}",
+                params.clusterOptions ?: "",
+                "-p ${params.gpu_partition}",
+                params.gpu_gres ? "--gpus=${params.gpu_gres}" : '--gpus=l40s:1'
+            ].minus("").join(" ")
+        }
     }
 }
 


### PR DESCRIPTION
---
name: GPU configuration on pelle
about: Configures SLURM resources for GPU labelled processes
---

- For GPU labelled processes, the SLURM partition & requested resources must be configured on the workflow side, which is not reproducible across clusters
- The PR adds configuration for the Pelle cluster and has been tested using `parabricks fq2bam`

Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any

Steps for adding a new config profile:

- [ ] Add your custom config file to the `conf/` directory
- [ ] Add your documentation file to the `docs/` directory
- [ ] Add your custom profile to the `nfcore_custom.config` file in the top-level directory
- [ ] Add your profile name to the `profile:` scope in `.github/workflows/main.yml`
- [ ] OPTIONAL: Add your custom profile path and GitHub user name to `.github/CODEOWNERS` (`**/<custom-profile>** @<github-username>`)

<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
