### PR TITLE
Recent palmetto cluster update required removal of TMPDIR setting from palmetto.config

### DIFF
--- a/conf/palmetto.config
+++ b/conf/palmetto.config
@@ -24,8 +24,6 @@ params {
 
 validation.ignoreParams = ["work1"]
 
-env.TMPDIR = "/local_scratch/slurm.${System.getenv('SLURM_JOBID')}"
-
 cleanup = false
 
 executor {


### PR DESCRIPTION
Removed TMPDIR environment variable configuration.

My apologies, a change in our system was brought to my attention after the previous pull request was merged. Removal of my setting of TMPDIR is required.

---
name: update to palmetto Config
about: removed 1 line from palmetto cluster config
---

Please follow these steps before submitting your PR:

- [ ] If your PR is a work in progress, include `[WIP]` in its title
- [X] Your PR targets the `master` branch
- [ ] You've included links to relevant issues, if any


<!--
If you require/still waiting for a review, please feel free to request a review from @nf-core/maintainers

Please see uploading to`nf-core/configs` for more details:
https://github.com/nf-core/configs#uploading-to-nf-coreconfigs

Thank you for contributing to nf-core!
-->
