### PR TITLE
Replace params.gpu_gres with per-process accelerator on Pelle

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -14,8 +14,8 @@ params {
     config_profile_url           = 'https://www.uppmax.uu.se/'
     project                      = null
     clusterOptions               = null
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,gpu_gres,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,schema_ignore_params"
     save_reference               = true
     // Defaults set for Bianca - other clusters set using includeConfig below
     max_memory                   = 500.GB
@@ -28,7 +28,6 @@ params {
         "clusterOptions",
         "clusterName",
         "genomes",
-        "gpu_gres",
         "ignore_params_list",
         "input_paths",
         "max_cpus",

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -14,8 +14,8 @@ params {
     config_profile_url           = 'https://www.uppmax.uu.se/'
     project                      = null
     clusterOptions               = null
-    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project"
-    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,schema_ignore_params"
+    schema_ignore_params         = "genomes,input_paths,cluster-options,clusterOptions,project,pelle_gpu_type"
+    validationSchemaIgnoreParams = "genomes,input_paths,cluster-options,clusterOptions,project,pelle_gpu_type,schema_ignore_params"
     save_reference               = true
     // Defaults set for Bianca - other clusters set using includeConfig below
     max_memory                   = 500.GB
@@ -33,6 +33,7 @@ params {
         "max_cpus",
         "max_memory",
         "max_time",
+        "pelle_gpu_type",
         "project",
         "schema_ignore_params",
         "validationSchemaIgnoreParams",

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -3,7 +3,6 @@
 
 params {
     config_profile_description = 'UPPMAX (Pelle) cluster profile provided by nf-core/configs.'
-    gpu_gres                   = 'l40s:1' // GPU generic resources: https://slurm.schedmd.com/gres.html
     max_cpus                   = 96
     max_memory                 = 3.TB
     max_time                   = 10.d
@@ -17,29 +16,37 @@ process {
         memory: 3.TB,
         time: 10.d,
     ]
+
+    // Default GPU for any process labelled `process_gpu` (e.g. via `-profile gpu`).
+    // Override per process in your own config, e.g.:
+    //   withName: 'GPU_PROCESS' { accelerator = [ type: 'h100', request: 2 ] }
+    withLabel: process_gpu {
+        accelerator = { workflow.profile.contains('gpu') ? [ type: 'l40s', request: 1 ] : null }
+    }
+
     clusterOptions = {
-        // https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#partitions-on-pelle
-        def gpu_partition = [
-            'l40s': 'gpu',
-            'h100': 'gpu',
-            't4': 'haswell'
-        ]
-        def gpu_parts = params.gpu_gres.tokenize(':')
-        def gpu_type  = (gpu_parts.size() > 1) ? gpu_parts.head() : 'l40s'
-        if (task.accelerator && !gpu_partition.containsKey(gpu_type)) {
-            throw new IllegalArgumentException(
-                "gpu_gres '${params.gpu_gres}' specifies unknown GPU type '${gpu_type}'. Valid types: ${gpu_partition.keySet().sort().join(', ')}"
-            )
+        def gpu_directive = ""
+        // Follows the nf-core GPU guidelines: https://nf-co.re/docs/developing/components/gpu-modules
+        if (task.accelerator) {
+            // https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#partitions-on-pelle
+            def gpu_partition = [
+                'l40s': 'gpu',
+                'h100': 'gpu',
+                't4': 'haswell'
+            ]
+            def gpu_type = task.accelerator.type ?: 'l40s'
+            if (!gpu_partition.containsKey(gpu_type)) {
+                throw new IllegalArgumentException(
+                    "accelerator type '${gpu_type}' is unknown. Valid types: ${gpu_partition.keySet().sort().join(', ')}"
+                )
+            }
+            gpu_directive = "-p ${gpu_partition[gpu_type]} --gpus=${gpu_type}:${task.accelerator.request ?: 1}"
         }
 
         [
             "-A ${params.project}",
             params.clusterOptions ?: "",
-            task.accelerator // Follows implementation pattern described by https://nf-co.re/docs/developing/components/gpu-modules
-                ? "-p ${gpu_partition[gpu_type]} --gpus=${params.gpu_gres}"
-                : task.memory > 768.GB
-                    ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}"
-                    : "",
+            gpu_directive ?: (task.memory > 768.GB ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}" : ""),
         ].minus("").join(" ")
     }
 }

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -52,4 +52,6 @@ process {
 
 singularity {
     runOptions = '-B $SNIC_TMP'
+    // Forward Slurm's per-job GPU visibility restriction into the container.
+    envWhitelist = 'SNIC_TMP,CUDA_VISIBLE_DEVICES'
 }

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -48,5 +48,5 @@ process {
 }
 
 singularity {
-    runOptions = '-B $SNIC_TMP'
+    runOptions = '-B $SNIC_TMP --nv'
 }

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -3,6 +3,7 @@
 
 params {
     config_profile_description = 'UPPMAX (Pelle) cluster profile provided by nf-core/configs.'
+    pelle_gpu_type             = 'l40s' // Default accelerator type when a task doesn't request a specific one
     max_cpus                   = 96
     max_memory                 = 3.TB
     max_time                   = 10.d
@@ -17,16 +18,11 @@ process {
         time: 10.d,
     ]
 
-    // Default GPU for any process labelled `process_gpu` (e.g. via `-profile gpu`).
-    // Override per process in your own config, e.g.:
-    //   withName: 'GPU_PROCESS' { accelerator = [ type: 'h100', request: 2 ] }
-    withLabel: process_gpu {
-        accelerator = { workflow.profile.contains('gpu') ? [ type: 'l40s', request: 1 ] : null }
-    }
-
     clusterOptions = {
         def gpu_directive = ""
         // Follows the nf-core GPU guidelines: https://nf-co.re/docs/developing/components/gpu-modules
+        // Any task.accelerator (e.g. set by a pipeline's `process_gpu` label under `-profile gpu`)
+        // defaults to params.pelle_gpu_type unless the accelerator itself specifies one.
         if (task.accelerator) {
             // https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#partitions-on-pelle
             def gpu_partition = [
@@ -34,7 +30,7 @@ process {
                 'h100': 'gpu',
                 't4': 'haswell'
             ]
-            def gpu_type = task.accelerator.type ?: 'l40s'
+            def gpu_type = task.accelerator.type ?: params.pelle_gpu_type
             if (!gpu_partition.containsKey(gpu_type)) {
                 throw new IllegalArgumentException(
                     "accelerator type '${gpu_type}' is unknown. Valid types: ${gpu_partition.keySet().sort().join(', ')}"

--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -45,8 +45,11 @@ process {
             gpu_directive ?: (task.memory > 768.GB ? "-p fat -C ${task.memory > 2.TB ? '3TB' : '2TB'}" : ""),
         ].minus("").join(" ")
     }
+
+    // Enables GPU access inside the container when a task requests an accelerator.
+    containerOptions = { task.accelerator ? '--nv' : '' }
 }
 
 singularity {
-    runOptions = '-B $SNIC_TMP --nv'
+    runOptions = '-B $SNIC_TMP'
 }

--- a/docs/uppmax.md
+++ b/docs/uppmax.md
@@ -76,15 +76,17 @@ To use it, submit with `-profile uppmax,devel`.
 
 ## Using GPUs on Pelle
 
-nf-core pipelines mark GPU-capable processes with the `process_gpu` label and only switch on the accelerator when you add nf-core's `gpu` profile (see the [nf-core GPU guidelines](https://nf-co.re/docs/developing/components/gpu-modules)). On `pelle`, the `uppmax` profile supplies a default of one `l40s` GPU for any `process_gpu` task, and derives the correct Slurm partition (`gpu` or `haswell`) and `--gpus` request from Nextflow's [`accelerator` directive](https://www.nextflow.io/docs/latest/reference/process.html#accelerator).
+nf-core pipelines mark GPU-capable processes with the `process_gpu` label and only switch on the accelerator when you add nf-core's `gpu` profile (see the [nf-core GPU guidelines](https://nf-co.re/docs/developing/components/gpu-modules)). Whatever a task's Nextflow [`accelerator` directive](https://www.nextflow.io/docs/latest/reference/process.html#accelerator) ends up being (e.g. the pipeline's own `accelerator = 1` default under `-profile gpu`), the `uppmax` profile on `pelle` derives the correct Slurm partition (`gpu` or `haswell`) and `--gpus` request from it, defaulting the GPU type to `params.pelle_gpu_type` (`l40s`) when the accelerator doesn't specify one itself.
 
 ```bash
 $ nextflow run nf-core/<PIPELINE> -profile gpu,uppmax --project <PROJECT> [...]
 ```
 
-### Requesting a different GPU type or count
+Override the default type for every otherwise-unspecified GPU task with `--pelle_gpu_type <type>`, e.g. `--pelle_gpu_type h100`.
 
-To use a GPU other than the default `l40s`, or to request more than one GPU, override the `accelerator` directive for the process(es) that need it, in your own config:
+### Requesting a different GPU type or count per process
+
+To use a GPU other than the default, or to request more than one GPU for a specific process, override the `accelerator` directive for the process(es) that need it, in your own config:
 
 ```nextflow
 // gpu_configuration.config

--- a/docs/uppmax.md
+++ b/docs/uppmax.md
@@ -74,6 +74,43 @@ It is not suitable for use with real data.
 
 To use it, submit with `-profile uppmax,devel`.
 
+## Using GPUs on Pelle
+
+nf-core pipelines mark GPU-capable processes with the `process_gpu` label and only switch on the accelerator when you add nf-core's `gpu` profile (see the [nf-core GPU guidelines](https://nf-co.re/docs/developing/components/gpu-modules)). On `pelle`, the `uppmax` profile supplies a default of one `l40s` GPU for any `process_gpu` task, and derives the correct Slurm partition (`gpu` or `haswell`) and `--gpus` request from Nextflow's [`accelerator` directive](https://www.nextflow.io/docs/latest/reference/process.html#accelerator).
+
+```bash
+$ nextflow run nf-core/<PIPELINE> -profile gpu,uppmax --project <PROJECT> [...]
+```
+
+### Requesting a different GPU type or count
+
+To use a GPU other than the default `l40s`, or to request more than one GPU, override the `accelerator` directive for the process(es) that need it, in your own config:
+
+```nextflow
+// gpu_configuration.config
+process {
+    withName: 'GPU_PROCESS_ONE' {
+        accelerator = [ type: 'l40s', request: 4 ] // 4x l40s GPUs, submitted to -p gpu
+    }
+    withName: 'GPU_PROCESS_TWO' {
+        accelerator = [ type: 't4', request: 1 ] // 1x t4 GPU, submitted to -p haswell
+    }
+    withName: 'GPU_PROCESS_THREE' {
+        accelerator = null // Disable the GPU, run on CPU instead
+    }
+}
+```
+
+```bash
+$ nextflow run nf-core/<PIPELINE> -profile gpu,uppmax --project <PROJECT> -c gpu_configuration.config [...]
+```
+
+Valid GPU types on Pelle are `l40s`, `h100`, and `t4` (see [Pelle partitions](https://docs.uppmax.uu.se/cluster_guides/slurm_on_pelle/#partitions-on-pelle)); requesting any other type raises an error at submission time.
+
+### Running on a GPU node interactively
+
+The Pelle config only sets `clusterOptions` for the `slurm` executor. If you run locally on a GPU node (e.g. in an interactive session), set the `accelerator` directive as above and follow [Nextflow's local executor GPU guide](https://docs.seqera.io/nextflow/executor/local#accelerators) to make the GPU visible to the task.
+
 ## Running on Bianca
 
 > :warning: For more information, please follow the following guides:


### PR DESCRIPTION
## Summary

- Removes the pipeline-wide `params.gpu_gres` param from `conf/uppmax/pelle.config` in favor of Nextflow's standard `process.accelerator` directive, read per-task in `clusterOptions`.
- Adds a default of `[type: 'l40s', request: 1]` on any process labelled `process_gpu`, applied only when `-profile gpu` is active (`workflow.profile.contains('gpu')`) — matching the same gating nf-core's own `base.config` uses.
- Removes the now-dead `gpu_gres` entries from `conf/uppmax.config`'s ignore-params lists.
- Adds a "Using GPUs on Pelle" section to `docs/uppmax.md` documenting the per-process override pattern (different GPU type/count per process, and disabling the GPU for one process with `accelerator = null`).

## Why

A single `gpu_gres` param can't express different GPU needs for different processes in the same pipeline run, and changing it risks invalidating `-resume` state for unrelated tasks. Follows the design discussed in [NBISweden/biovat#45](https://github.com/NBISweden/biovat/issues/45#issuecomment-5277374410).