### PR TITLE
bump highmem threshold to 250GB and add bash login shell to all jobs

### DIFF
--- a/conf/dkfz.config
+++ b/conf/dkfz.config
@@ -2,7 +2,7 @@
 
 params {
     config_profile_description = 'Deutsches Krebsforschungszentrum (DKFZ) ODCF HPC cluster profile'
-    config_profile_contact     = 'Abid Abrar (abid.abrar@dkfz-heidelberg.de), Kübra Narcı (kuebra.narci@dkfz-heidelberg.de)'
+    config_profile_contact     = 'Abid Abrar (abid.abrar@dkfz-heidelberg.de), Kübra Narcı (kuebra.narci@dkfz-heidelberg.de), Vithusan Suppiyar (vithusan.suppiyar@dkfz-heidelberg.de)'
     config_profile_name        = 'DKFZ Cluster'
     config_profile_url         = 'https://www.dkfz.de'
 
@@ -47,7 +47,7 @@ process {
     queue = {
         if (task.accelerator) {
             return params.dkfz_gpu_queue
-        } else if (task.memory && task.memory > 200.GB) {
+        } else if (task.memory && task.memory > 250.GB) {
             return 'highmem'
         } else if (!task.time || task.time <= 10.min) {
             return 'short'
@@ -65,14 +65,14 @@ process {
     // j_exclusive=yes is mandatory
     // optional `ext.gpu_memory` pins to GPUs with at least that much VRAM.
     clusterOptions = {
-        if (!task.accelerator) {
-            return null
+        def opts = '-L /bin/bash'
+        if (task.accelerator) {
+            opts += " -gpu num=${task.accelerator.request}:j_exclusive=yes"
+            if (task.ext.gpu_memory) {
+                opts += ":gmem=${task.ext.gpu_memory.toGiga()}G"
+            }
         }
-        def gpu = "-gpu num=${task.accelerator.request}:j_exclusive=yes"
-        if (task.ext.gpu_memory) {
-            gpu += ":gmem=${task.ext.gpu_memory.toGiga()}G"
-        }
-        return gpu
+        return opts
     }
 
     // Bind /omics into every container; add --nv for GPU tasks.

--- a/conf/dkfz.config
+++ b/conf/dkfz.config
@@ -7,7 +7,7 @@ params {
     config_profile_url         = 'https://www.dkfz.de'
 
     max_cpus   = 64
-    max_memory = '1000.GB'
+    max_memory = '3800.GB'
     max_time   = '720.h'
 
     // GPU queue for GPU jobs (options: gpu (default), gpu-lowprio, gpu-pro)
@@ -31,10 +31,10 @@ process {
     maxRetries    = 3
     cache         = 'lenient'
 
-    // Cap every task to the cluster ceiling: 64 cores, 1000 GB RAM, 720 h (30 day) wall time
+    // Cap every task to the cluster ceiling: 64 cores, 3800 GB RAM, 720 h (30 day) wall time
     resourceLimits = [
         cpus  : 64,
-        memory: 1000.GB,
+        memory: 3800.GB,
         time  : 720.h,
     ]
 

--- a/docs/dkfz.md
+++ b/docs/dkfz.md
@@ -26,22 +26,12 @@ The profile only configures the cluster itself (LSF executor, dynamic queue sele
 
 ## Queues
 
-Queue selection is automatic, based on each task's requested `time` and `memory`:
-
-| Queue      | Selected when                       | Limit             |
-| ---------- | ----------------------------------- | ----------------- |
-| `short`    | no time given, or `time <= 10.min`  | 10 min            |
-| `medium`   | `time <= 1.h`                       | 1 hour            |
-| `long`     | `time <= 10.h`                      | 10 hours          |
-| `verylong` | `time > 10.h`                       | no hard limit     |
-| `highmem`  | `memory > 250.GB`                   | up to ~1 TB       |
-
-Note: `highmem` is the only queue that accepts requests above 250 GB (and it rejects requests below 251 GB).
+The profile selects an appropriate LSF queue automatically based on the task's resource requirements. See the [DKFZ Cluster Wiki](https://wiki.odcf.dkfz.de/pub/cluster/lsf/quickref#cpu_queues) for current queue and resource policies.
 
 ## Resource limits, retries and containers
 
-- Every task is capped to what the cluster can provide via `process.resourceLimits` (64 CPUs, 1000 GB memory, 720 h). Requests above these are capped automatically.
-- Unlabelled processes default to a safe 1 CPU / 6 GB / 10 min.
+- Every task is capped to what the cluster can provide via `process.resourceLimits`. Requests above these are capped automatically.
+- Unlabelled processes default to a safe minimal allocation; see the [DKFZ Cluster Wiki](https://wiki.odcf.dkfz.de/pub/cluster/lsf/quickref#cpu_queues) for the current default.
 - The shared `/omics` filesystem is bound into every container via `containerOptions`, with `--nv` added for accelerator tasks. **If one of your modules sets its own `containerOptions`, re-add `--bind /omics` there.**
 
 ## Enable GPU support
@@ -76,11 +66,7 @@ Tasks without an `accelerator` request are unaffected and run on the normal CPU 
 
 ### Choosing the GPU queue
 
-The `--dkfz_gpu_queue` parameter selects which GPU queue all GPU jobs are submitted to (default `gpu`):
-
-- `gpu` — default (RTX 2080 Ti … V100/A100-DGX), 72 h wall time
-- `gpu-lowprio` — same nodes as `gpu` but low priority; use for large job batches
-- `gpu-pro` — high-end A100/H200/L40S/GH200, 142 h wall time — **requires a separate access application to the DKFZ Data Science Board**
+The `--dkfz_gpu_queue` parameter selects which GPU queue all GPU jobs are submitted to (default `gpu`). For the current list of GPU queues, hardware, wall-time limits and access requirements, see the [DKFZ Cluster Wiki](https://wiki.odcf.dkfz.de/pub/cluster/lsf/quickref#gpu_queues).
 
 ### Number of GPUs and GPU memory per process
 
@@ -89,18 +75,7 @@ The profile builds the LSF request as `-gpu num=<n>:j_exclusive=yes[:gmem=<n>G]`
 - **Number of GPUs** — the [`accelerator` directive](https://www.nextflow.io/docs/latest/reference/process.html#accelerator) (default 1).
 - **GPU memory (optional)** — set `ext.gpu_memory` to a Nextflow memory value to pin the job to GPUs with at least that much VRAM. When `ext.gpu_memory` is unset, `gmem` is omitted and LSF assigns any free GPU.
 
-Approximate values to target each GPU tier (request at or just below the card's usable VRAM):
-
-| `ext.gpu_memory` | Targets                         | Queue              |
-| ---------------- | ------------------------------- | ------------------ |
-| `10.GB`          | RTX 2080 Ti (11 GB)             | `gpu`              |
-| `15.GB`          | V100 16 GB                      | `gpu`              |
-| `23.GB`          | TITAN RTX / Quadro RTX (24 GB)  | `gpu`              |
-| `31.GB`          | V100 32 GB                      | `gpu`              |
-| `40.GB`          | A100 40 GB                      | `gpu-pro` only     |
-| `46.GB`          | L40S                            | `gpu-pro` only     |
-| `98.GB`          | GH200                           | `gpu-pro` only     |
-| `141.GB`         | H200                            | `gpu-pro` only     |
+For approximate `ext.gpu_memory` values to target specific GPU models and which queue each requires, see the [DKFZ Cluster Wiki](https://wiki.odcf.dkfz.de/pub/cluster/lsf/gpu/start#gpu_queue_nodes).
 
 Set these directly on the process, or per process name from config (e.g. nf-core's `conf/modules.config`):
 
@@ -110,16 +85,16 @@ process {
     withName: 'FOO:BAR:ALIGN_GPU' {
         accelerator = 2
     }
-    // 1 big-memory GPU
+    // 1 big-memory GPU, needs gpu-pro - see DKFZ Cluster Wiki for current hardware tiers (https://wiki.odcf.dkfz.de/pub/cluster/lsf/gpu/start#gpu_queue_nodes)
     withName: 'FOO:BAR:FOLD' {
         accelerator    = 1
-        ext.gpu_memory = 40.GB   // -> A100/L40S/H200; also set --dkfz_gpu_queue gpu-pro
+        ext.gpu_memory = 40.GB
     }
 }
 ```
 
-> :warning: Requesting `40.GB` or more only works on `gpu-pro`. On the plain `gpu` queue such a request hangs in `PEND` forever. Use at most 12 CPUs and ~45 GB host RAM per GPU (DKFZ GPU usage policy).
-
+> :warning: A high `ext.gpu_memory` value may only be satisfiable on certain GPU queues - request too much on the wrong queue and the job hangs in `PEND` indefinitely. Check the [DKFZ Cluster Wiki](https://wiki.odcf.dkfz.de/pub/cluster/lsf/gpu/start#usage_policy) for current hardware/queue mapping and CPU/RAM-per-GPU usage limits before setting `ext.gpu_memory`.
+> 
 ## Running Nextflow on the cluster
 
 Run the Nextflow driver inside an LSF job rather than on a submission host directly. Make a script and submit it with `bsub < my_script.sh`:

--- a/docs/dkfz.md
+++ b/docs/dkfz.md
@@ -34,7 +34,7 @@ Queue selection is automatic, based on each task's requested `time` and `memory`
 | `medium`   | `time <= 1.h`                       | 1 hour            |
 | `long`     | `time <= 10.h`                      | 10 hours          |
 | `verylong` | `time > 10.h`                       | no hard limit     |
-| `highmem`  | `memory > 250.GB`                   | up to ~4 TB       |
+| `highmem`  | `memory > 250.GB`                   | up to ~1 TB       |
 
 Note: `highmem` is the only queue that accepts requests above 250 GB (and it rejects requests below 251 GB).
 

--- a/docs/dkfz.md
+++ b/docs/dkfz.md
@@ -2,7 +2,7 @@
 
 To use, run the pipeline with `-profile dkfz`. This will download and launch the [`dkfz.config`](../conf/dkfz.config), pre-configured for the Deutsches Krebsforschungszentrum (DKFZ) / ODCF LSF cluster in Heidelberg, Germany.
 
-This configuration is tested with Nextflow 25.10.0 (available on the cluster as a module).
+This configuration is tested with Nextflow 24.10.2 (available on the cluster as a module).
 
 The profile only configures the cluster itself (LSF executor, dynamic queue selection, scratch, resource limits and the `/omics` bind-mount). Pick a container engine on the command line, e.g. `-profile dkfz,apptainer` or `-profile dkfz,conda`.
 
@@ -13,7 +13,7 @@ The profile only configures the cluster itself (LSF executor, dynamic queue sele
 1. Load Nextflow via the environment module system on a submission host. Check the pipeline's README for the required Nextflow version:
 
    ```bash
-   module load Nextflow/25.10.0
+   module load Nextflow/24.10.2
    ```
 
 2. Submit from a submission host (`bsub01.lsf.dkfz.de` / `bsub02.lsf.dkfz.de`). Do **not** run heavy work on the login/worker nodes. Wrap the Nextflow driver itself in a `bsub` job (see below).
@@ -34,9 +34,9 @@ Queue selection is automatic, based on each task's requested `time` and `memory`
 | `medium`   | `time <= 1.h`                       | 1 hour            |
 | `long`     | `time <= 10.h`                      | 10 hours          |
 | `verylong` | `time > 10.h`                       | no hard limit     |
-| `highmem`  | `memory > 200.GB`                   | up to ~4 TB       |
+| `highmem`  | `memory > 250.GB`                   | up to ~4 TB       |
 
-Note: `highmem` is the only queue that accepts requests above 200 GB (and it rejects requests below 200 GB).
+Note: `highmem` is the only queue that accepts requests above 250 GB (and it rejects requests below 251 GB).
 
 ## Resource limits, retries and containers
 
@@ -133,7 +133,7 @@ Run the Nextflow driver inside an LSF job rather than on a submission host direc
 #BSUB -R "rusage[mem=8G]"
 #BSUB -W 10:00
 
-module load Nextflow/25.10.0
+module load Nextflow/24.10.2
 
 # Cache images on shared storage so worker nodes can reach them:
 export NXF_APPTAINER_CACHEDIR=/omics/groups/<your-group>/.../apptainer_cache

--- a/docs/dkfz.md
+++ b/docs/dkfz.md
@@ -13,7 +13,7 @@ The profile only configures the cluster itself (LSF executor, dynamic queue sele
 1. Load Nextflow via the environment module system on a submission host. Check the pipeline's README for the required Nextflow version:
 
    ```bash
-   module load Nextflow/24.10.2
+   module load Nextflow/<version>
    ```
 
 2. Submit from a submission host (`bsub01.lsf.dkfz.de` / `bsub02.lsf.dkfz.de`). Do **not** run heavy work on the login/worker nodes. Wrap the Nextflow driver itself in a `bsub` job (see below).
@@ -133,10 +133,11 @@ Run the Nextflow driver inside an LSF job rather than on a submission host direc
 #BSUB -R "rusage[mem=8G]"
 #BSUB -W 10:00
 
-module load Nextflow/24.10.2
+# Load the Nextflow version required by the pipeline you are running:
+# module load Nextflow/<version>
 
 # Cache images on shared storage so worker nodes can reach them:
-export NXF_APPTAINER_CACHEDIR=/omics/groups/<your-group>/.../apptainer_cache
+# export NXF_APPTAINER_CACHEDIR=/omics/groups/<your-group>/.../apptainer_cache
 
 nextflow run <pipeline> \
     -profile dkfz,apptainer \


### PR DESCRIPTION
Hi,

I've made small changes to the currently existing `dkfz.config` file. I have updated the `highmem` queue threshold from 200 GB to 250 GB. Further, I made sure that the job starts in a bash login shell by adding `-L /bin/bash` to `clusterOptions`. Previously, jobs could default to `sh`, which sometimes failed to properly initialize the environment (e.g. `nextflow` not being on `PATH`), causing issues. In addition to that, I had to downgrade from `Nextflow/25.10.0` to `Nextflow/24.10.2` (available as cluster module) in the docs, otherwise you are running into this [known issue](https://github.com/nextflow-io/nextflow/issues/6517).

This is not a new profile. `dkfz` is already registered in `nfcore_custom.config` and `.github/workflows/main.yml`. @kubranarci @abidabrar.