### PR TITLE
Add local executor resource limits to PDC KTH profile

### DIFF
--- a/conf/pdc_kth.config
+++ b/conf/pdc_kth.config
@@ -46,6 +46,14 @@ validation {
 params.schema_ignore_params = params.ignore_params_list.join(",")
 params.validationSchemaIgnoreParams = params.ignore_params_list.join(",")
 
+// Cap local jobs so they don't overburden the shared login node
+executor {
+    $local {
+        cpus   = 8
+        memory = 128.GB
+    }
+}
+
 // Apptainer settings
 singularity {
     enabled    = true


### PR DESCRIPTION
## Summary

- Cap the `local` executor on the `pdc_kth` profile to 8 CPUs / 128GB memory, so processes marked to run locally (short jobs that don't go through Slurm) don't fan out and overburden the shared Dardel login node.