### PR TITLE
Add local executor resource limits to Pelle profile

### DIFF
--- a/conf/uppmax/pelle.config
+++ b/conf/uppmax/pelle.config
@@ -55,3 +55,11 @@ singularity {
     // Forward Slurm's per-job GPU visibility restriction into the container.
     envWhitelist = 'SNIC_TMP,CUDA_VISIBLE_DEVICES'
 }
+
+// Cap local jobs so they don't overburden the shared login node
+executor {
+    $local {
+        cpus   = 8
+        memory = 128.GB
+    }
+}


### PR DESCRIPTION
## Summary

- Cap the `local` executor on the `pelle` profile to 8 CPUs / 128GB memory, so processes marked to run locally (short jobs that don't go through Slurm) don't fan out and overburden the shared Pelle login node.
