### PR TITLE
Remove 'scratch' option from executor Cambridge configuration

### DIFF
--- a/conf/cambridge.config
+++ b/conf/cambridge.config
@@ -69,7 +69,6 @@ process {
     queue          = params.partition
     clusterOptions = { params.project ? "--account=${params.project}" : '' }
     cache          = 'lenient'
-    scratch        = true
 }
 
 executor {


### PR DESCRIPTION
Removed the 'scratch' option from the executor configuration. We have discovered though usage that `scratch` option is not working well for our cluster as the default `tmp` gets full quite easily. Therefore I am removing this option from the config, users can still activate it through their config if they wish to.
