### PR TITLE
purdue_gautschi & purdue_negishi: add apptainer libraryDir for shared…

### DIFF
--- a/conf/purdue_gautschi.config
+++ b/conf/purdue_gautschi.config
@@ -86,5 +86,7 @@ executor {
 apptainer {
     enabled    = true
     autoMounts = true
+    // Site-wide read-only store of pre-pulled images. Checked first; never written.
+    libraryDir = '/apps/external/nf-core/singularity-images'
     cacheDir   = "${System.getenv('RCAC_SCRATCH') ?: System.getenv('SCRATCH') ?: System.getProperty('user.home')}/.apptainer/cache"
 }

--- a/conf/purdue_negishi.config
+++ b/conf/purdue_negishi.config
@@ -60,5 +60,7 @@ executor {
 apptainer {
     enabled    = true
     autoMounts = true
+    // Site-wide read-only store of pre-pulled images. Checked first; never written.
+    libraryDir = '/apps/external/nf-core/singularity-images'
     cacheDir   = "${System.getenv('RCAC_SCRATCH') ?: System.getenv('SCRATCH') ?: System.getProperty('user.home')}/.apptainer/cache"
 }

--- a/docs/purdue_gautschi.md
+++ b/docs/purdue_gautschi.md
@@ -69,7 +69,7 @@ To use your own reference instead, pass the relevant pipeline parameters explici
 ## Container cache and work directory
 
 ```bash
-export NXF_SINGULARITY_CACHEDIR=$RCAC_SCRATCH/.apptainer/cache
+export NXF_APPTAINER_CACHEDIR=$RCAC_SCRATCH/.apptainer/cache
 nextflow run ... -w $RCAC_SCRATCH/nextflow-work ...
 ```
 

--- a/docs/purdue_negishi.md
+++ b/docs/purdue_negishi.md
@@ -62,7 +62,7 @@ To use your own reference instead, pass the relevant pipeline parameters explici
 ## Container cache and work directory
 
 ```bash
-export NXF_SINGULARITY_CACHEDIR=$RCAC_SCRATCH/.apptainer/cache
+export NXF_APPTAINER_CACHEDIR=$RCAC_SCRATCH/.apptainer/cache
 nextflow run ... -w $RCAC_SCRATCH/nextflow-work ...
 ```
 


### PR DESCRIPTION
Please follow these steps before submitting your PR:

- [x] If your PR is a work in progress, include `[WIP]` in its title
- [x] Your PR targets the `master` branch
- [x] You've included links to relevant issues, if any

<!-- This PR modifies two existing profiles; the "adding a new config profile" steps
     from the template do not apply (no new conf/, docs/, nfcore_custom.config,
     main.yml or CODEOWNERS entries are needed). -->

## Summary

Adds `apptainer.libraryDir` to the `purdue_gautschi` and `purdue_negishi` profiles so pipelines use RCAC's shared store of pre-pulled container images, and corrects two related points in the profile docs.

## Why

Both profiles set only `apptainer.cacheDir`, pointing at per-user scratch. RCAC maintains a site-wide store of pre-pulled images, but nothing in either profile referenced it, so every user re-pulled and re-converted every image.

This surfaced as a hard failure rather than just wasted time. A user running nf-core/sarek through our Open OnDemand gateway hit an OOM in the launcher job while converting two large GATK images to squashfs. Each conversion was killed partway, leaving a SIF with a valid header and no payload, and subsequent runs failed with:

```
FATAL: While checking container encryption: could not open image ...gatk4_gcnvkernel_htslib_samtools-c1e4292d6ee27439.img: ... not a valid squashfs image
```

Both images were already present and complete in the shared store, under exactly the filenames Nextflow generates. The failure was observed on Gautschi; Negishi had the same omission.

## Changes

- `conf/purdue_gautschi.config`, `conf/purdue_negishi.config`: add `libraryDir`; `cacheDir` unchanged as the per-user fallback.
- `docs/purdue_gautschi.md`, `docs/purdue_negishi.md`: document the shared store; replace `NXF_SINGULARITY_CACHEDIR` with `NXF_APPTAINER_CACHEDIR`, since these profiles enable the Apptainer scope and the Singularity variable is ignored.
- Same docs: `module purge` to `module --force purge` in the prerequisites, since sticky modules otherwise inject a newer glibc that breaks containerised tools.

## Testing

Tested on Gautschi with nf-core/sarek <version>: with this change the previously re-pulled images resolve from the shared store and no download occurs.

`libraryDir` requires Nextflow >= 22.12.
